### PR TITLE
feat(SchemaGeneration): Stitch resolved schemas into Swagger JSON

### DIFF
--- a/lib/swag.ex
+++ b/lib/swag.ex
@@ -3,68 +3,58 @@ defmodule Swag do
   Documentation for Swag.
   """
 
-  alias Swag.PipeThroughMap
+  alias Swag.{Config, Route}
 
-  defstruct [
-    :body,
-    :description,
-    :path,
-    :pipe_through,
-    :query_params,
-    :responses,
-    :tags,
-    :verb,
-    headers: %{},
-    metadata: %{}
-  ]
-
-  @type t :: %__MODULE__{
-          body: binary(),
-          description: binary(),
-          headers: %{},
-          metadata: %{},
-          path: binary(),
-          pipe_through: [atom()],
-          query_params: %{},
-          responses: %{},
-          tags: [binary()],
-          verb: atom()
-        }
-
+  @spec generate_documentation(Config.t()) :: :ok | {:error, any()}
   def generate_documentation(config) do
-    %{processor: processor, writer: writer} = config
-    writer = Keyword.fetch!(writer, :module)
+    routes = generate_routes(config)
+    schemas = generate_schemas(routes)
+    processed = process(config, routes, schemas)
 
-    {:ok, device} = writer.init(config)
-    writer.write(device, processor.init(config))
-
-    flow =
-      config.router.__routes__
-      |> Flow.from_enumerable()
-      |> Flow.map(&generate_swag_struct(&1, config))
-
-    schemas =
-      flow
-      |> Flow.reduce(fn -> %{} end, &generate_schema_refs/2)
-      |> Map.new()
-
-    paths =
-      flow
-      |> Flow.reject(fn item ->
-        case config.filter do
-          :none -> false
-          filter -> item == filter
-        end
-      end)
-      |> Flow.map(&processor.process(&1, schemas, config))
-      |> Enum.join(",")
-
-    writer.write(device, paths)
-    writer.write(device, processor.finalize(config))
-    writer.close(device)
+    write(config, processed)
   end
 
-  def generate_schema_refs(%Swag{responses: responses}, acc) do
+  @spec generate_routes(Config.t()) :: [Route.t()]
+  def generate_routes(%Config{router: router} = config) do
+    router.__routes__()
+    |> Flow.from_enumerable()
+    |> Flow.map(&Route.generate_route(&1, config))
+    |> Flow.reject(fn route ->
+      case config.filter do
+        :none -> false
+        filter -> route == filter
+      end
+    end)
+    |> Enum.to_list()
+  end
+
+  @spec generate_schemas([Route.t()]) :: map()
+  def generate_schemas(routes) do
+    routes
+    |> Flow.from_enumerable()
+    |> Flow.reduce(fn -> %{} end, &generate_schemas/2)
+    |> Map.new()
+  end
+
+  @spec process(Config.t(), [Route.t()], map()) :: String.t()
+  def process(%Config{processor: processor} = config, routes, schemas) do
+    processor.process(config, routes, schemas)
+  end
+
+  @spec write(Config.t(), String.t()) :: :ok | {:error, any()}
+  def write(%Config{writer: writer} = config, processed) do
+    writer = Keyword.fetch!(writer, :module)
+
+    with {:ok, device} <- writer.init(config),
+         :ok <- writer.write(device, processed),
+         :ok <- writer.close(device) do
+      :ok
+    else
+      err -> err
+    end
+  end
+
+  defp generate_schemas(%Route{responses: responses}, acc) do
     Enum.reduce(responses, acc, fn {_, v}, refs ->
       case can_generate_schema?(v) do
         true -> Map.put_new(refs, v, v.to_json_schema())
@@ -73,87 +63,9 @@ defmodule Swag do
     end)
   end
 
-  defp can_generate_schema?(mod) when is_atom(mod),
-    do: :erlang.function_exported(mod, :to_json_schema, 0)
+  defp can_generate_schema?(mod) when is_atom(mod) do
+    :erlang.function_exported(mod, :to_json_schema, 0)
+  end
 
   defp can_generate_schema?(_), do: false
-
-  def generate_swag_struct(route, config) do
-    %{path: path, pipe_through: pipe_through, plug: plug, verb: verb, opts: action} = route
-
-    Code.fetch_docs(plug)
-    |> find_action(action)
-    |> new(config, path: path, pipe_through: pipe_through, plug: plug, verb: verb)
-  end
-
-  def new(doc, config, kwl \\ []) do
-    {description, documentation_metadata} = process(doc)
-
-    optional = Map.new(kwl)
-
-    description =
-      case description do
-        :none -> ""
-        description when is_map(description) -> Map.get(description, config.locale)
-        description -> description
-      end
-
-    %{headers: pipe_headers} =
-      optional
-      |> Map.get(:pipe_through)
-      |> pipe_through_mapping(config)
-
-    headers = Map.get(documentation_metadata, :headers, %{})
-    headers = deep_merge(pipe_headers, headers)
-
-    data =
-      optional
-      |> deep_merge(documentation_metadata)
-      |> deep_merge(%{headers: headers})
-      |> Map.put(:description, description)
-      |> Map.put(:metadata, Map.get(documentation_metadata, :metadata, %{}))
-
-    struct(%__MODULE__{}, data)
-  end
-
-  def process(doc) do
-    {_, _, _, desc, metadata} = doc
-
-    {desc, metadata}
-  end
-
-  def pipe_through_mapping(nil, _), do: PipeThroughMap.new()
-  def pipe_through_mapping(_, %{pipe_through_mapping: nil}), do: PipeThroughMap.new()
-
-  def pipe_through_mapping(pipe_through, config) when is_list(pipe_through) do
-    Enum.reduce(pipe_through, PipeThroughMap.new(), fn pt, acc ->
-      case pipe_through_mapping(pt, config) do
-        nil ->
-          acc
-
-        mapping ->
-          Map.merge(acc, mapping, fn
-            k, v1, v2 when k in [:headers, :query_params, :body] -> Map.merge(v1, v2)
-            _, _, v2 -> v2
-          end)
-      end
-    end)
-  end
-
-  def pipe_through_mapping(pipe_through, config) do
-    Map.get(config.pipe_through_mapping, pipe_through, nil)
-    |> PipeThroughMap.new()
-  end
-
-  defp deep_merge(left, right), do: Map.merge(left, right, &deep_resolve/3)
-  defp deep_resolve(_key, left = %{}, right = %{}), do: deep_merge(left, right)
-  defp deep_resolve(_key, _left, right), do: right
-
-  defp find_action(docs, action) do
-    {_, _, _, _, _, _, function_documentation} = docs
-
-    Enum.find(function_documentation, fn {{:function, ac, _arity}, _, _, _, _} ->
-      ac == action
-    end)
-  end
 end

--- a/lib/swag/processors/processor.ex
+++ b/lib/swag/processors/processor.ex
@@ -1,33 +1,34 @@
 defmodule Swag.Processor do
   @moduledoc """
-  Takes a Swag.t and converts it into a desireable output. The only function you
-  really need to implement is process/2. init/1 and finalize/1 are used to
-  surround the data thats processed with things that you only want to do at the
-  beginning or the end of the file respectively.
+  Takes a Swag.Config.t(), a list of Swag.Route.t(), and a map of response
+  schemas. Transforms them into a desirable output in the form of a JSON string.
+  The only required function is process/3, which is responsible for coordinating
+  processing and returning the formatted JSON.
   """
 
-  @optional_callbacks init: 1, finalize: 1
+  @optional_callbacks process_headers: 1, process_routes: 2, process_schemas: 1
 
   @doc """
   Process is responsible for turning each Swag.t() it receives and turning it
   into a string so that it can be written.
   """
-  @callback process(Swag.t(), map(), Swag.Config.t()) :: String.t()
+  @callback process(Swag.Config.t(), [Swag.Route.t()], schemas :: map()) :: String.t()
 
   @doc """
-  Init is responsible for returning a string that should get written at the top
-  of the file. In the case of swagger, init returns information such as
-  `version`, `title`, and `description`. Keep in mind that this function may not
-  return valid json. The only requirement is that it's a string.
+  Generates top-level metadata for the JSON output.
   """
-  @callback init(Swag.Config.t()) :: String.t()
+  @callback process_headers(Swag.Config.t()) :: map()
+  def process_headers(_), do: %{}
 
   @doc """
-  Like init, finalize is to put anything that needs to go at the end of the
-  document.
+  Transforms each Swag.Route.t() into a map to be added to the final JSON blob.
   """
-  @callback finalize(Swag.Config.t()) :: String.t()
+  @callback process_routes([Swag.Route.t()], schemas :: map()) :: map()
+  def process_routes(_, _), do: %{}
 
-  def init(_), do: ""
-  def finalize(_), do: ""
+  @doc """
+  Transforms the schemas map into a map to be added to the final JSON blob.
+  """
+  @callback process_schemas(schemas :: map()) :: map()
+  def process_schemas(_), do: %{}
 end

--- a/lib/swag/processors/swagger.ex
+++ b/lib/swag/processors/swagger.ex
@@ -3,16 +3,49 @@ defmodule Swag.Processors.Swagger do
   @open_api_version "3.0.0"
 
   @impl Swag.Processor
-  def process(%Swag{} = data, schemas, _config) do
+  def process(config, routes, schemas) do
+    headers = process_headers(config)
+    processed_routes = process_routes(routes, schemas)
+    processed_schemas = process_schemas(schemas)
+
+    finalize(headers, processed_routes, processed_schemas)
+  end
+
+  @impl Swag.Processor
+  def process_headers(config) do
     %{
-      data.path => %{
-        data.verb => %{
-          "description" => data.description,
-          "responses" => process_responses(data.responses, schemas)
+      "openapi" => @open_api_version,
+      "info" => %{
+        "title" => config.title,
+        "description" => config.description,
+        "version" => config.version
+      }
+    }
+  end
+
+  @impl Swag.Processor
+  def process_routes(routes, schemas) do
+    routes
+    |> Flow.from_enumerable()
+    |> Flow.map(&process_route(&1, schemas))
+    |> Enum.to_list()
+  end
+
+  @impl Swag.Processor
+  def process_schemas(schemas) do
+    schemas
+    |> Map.new(fn {mod, schema} -> {mod.__object__(:name), schema} end)
+  end
+
+  defp process_route(route, schemas) do
+    %{
+      route.path => %{
+        route.verb => %{
+          "description" => route.description,
+          "responses" => process_responses(route.responses, schemas)
         }
       }
     }
-    |> Jason.encode!()
   end
 
   defp process_responses(responses, schemas) do
@@ -22,29 +55,19 @@ defmodule Swag.Processors.Swagger do
 
   defp process_response({status_code, response}, schemas) when is_atom(response) do
     case Map.get(schemas, response) do
-      nil -> {status_code, response}
-      _ -> {status_code, "#/components/#{response.__object__(:type)}s/#{response.__object__(:name)}"}
+      nil ->
+        {status_code, response}
+
+      _ ->
+        {status_code, "#/components/#{response.__object__(:type)}s/#{response.__object__(:name)}"}
     end
   end
 
   defp process_response(response, _), do: response
 
-  @impl Swag.Processor
-  def init(config) do
-    """
-    {\"info\":{
-      \"description\":\"#{config.description}\",
-      \"title\":\"#{config.title}\",
-      \"version\":\"#{config.version}\"},
-    \"openapi\":\"#{@open_api_version}\",
-    \"paths\":[
-    """
-  end
-
-  @impl Swag.Processor
-  def finalize(_config) do
-    """
-    ]}
-    """
+  defp finalize(headers, routes, schemas) do
+    headers
+    |> Map.merge(%{"paths" => routes, "components" => %{"schemas" => schemas}})
+    |> Jason.encode!()
   end
 end

--- a/lib/swag/route.ex
+++ b/lib/swag/route.ex
@@ -1,0 +1,112 @@
+defmodule Swag.Route do
+  @moduledoc """
+  Logic to process and represent a single route path in your API.
+  """
+
+  alias Swag.PipeThroughMap
+
+  defstruct [
+    :body,
+    :description,
+    :path,
+    :pipe_through,
+    :query_params,
+    :responses,
+    :tags,
+    :verb,
+    headers: %{},
+    metadata: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          body: binary(),
+          description: binary(),
+          headers: %{},
+          metadata: %{},
+          path: binary(),
+          pipe_through: [atom()],
+          query_params: %{},
+          responses: %{},
+          tags: [binary()],
+          verb: atom()
+        }
+
+  def generate_route(route, config) do
+    %{path: path, pipe_through: pipe_through, plug: plug, verb: verb, opts: action} = route
+
+    Code.fetch_docs(plug)
+    |> find_action(action)
+    |> new(config, path: path, pipe_through: pipe_through, plug: plug, verb: verb)
+  end
+
+  def new(doc, config, kwl \\ []) do
+    {description, documentation_metadata} = process(doc)
+
+    optional = Map.new(kwl)
+
+    description =
+      case description do
+        :none -> ""
+        description when is_map(description) -> Map.get(description, config.locale)
+        description -> description
+      end
+
+    %{headers: pipe_headers} =
+      optional
+      |> Map.get(:pipe_through)
+      |> pipe_through_mapping(config)
+
+    headers = Map.get(documentation_metadata, :headers, %{})
+    headers = deep_merge(pipe_headers, headers)
+
+    data =
+      optional
+      |> deep_merge(documentation_metadata)
+      |> deep_merge(%{headers: headers})
+      |> Map.put(:description, description)
+      |> Map.put(:metadata, Map.get(documentation_metadata, :metadata, %{}))
+
+    struct(%__MODULE__{}, data)
+  end
+
+  def process(doc) do
+    {_, _, _, desc, metadata} = doc
+
+    {desc, metadata}
+  end
+
+  def pipe_through_mapping(nil, _), do: PipeThroughMap.new()
+  def pipe_through_mapping(_, %{pipe_through_mapping: nil}), do: PipeThroughMap.new()
+
+  def pipe_through_mapping(pipe_through, config) when is_list(pipe_through) do
+    Enum.reduce(pipe_through, PipeThroughMap.new(), fn pt, acc ->
+      case pipe_through_mapping(pt, config) do
+        nil ->
+          acc
+
+        mapping ->
+          Map.merge(acc, mapping, fn
+            k, v1, v2 when k in [:headers, :query_params, :body] -> Map.merge(v1, v2)
+            _, _, v2 -> v2
+          end)
+      end
+    end)
+  end
+
+  def pipe_through_mapping(pipe_through, config) do
+    Map.get(config.pipe_through_mapping, pipe_through, nil)
+    |> PipeThroughMap.new()
+  end
+
+  defp deep_merge(left, right), do: Map.merge(left, right, &deep_resolve/3)
+  defp deep_resolve(_key, left = %{}, right = %{}), do: deep_merge(left, right)
+  defp deep_resolve(_key, _left, right), do: right
+
+  defp find_action(docs, action) do
+    {_, _, _, _, _, _, function_documentation} = docs
+
+    Enum.find(function_documentation, fn {{:function, ac, _arity}, _, _, _, _} ->
+      ac == action
+    end)
+  end
+end

--- a/test/swag/processors/swagger_test.exs
+++ b/test/swag/processors/swagger_test.exs
@@ -1,6 +1,7 @@
 defmodule Swag.Processors.SwaggerTest do
   use ExUnit.Case
 
+  alias Swag.Route
   alias Swag.Processors.Swagger
 
   defmodule User do
@@ -14,7 +15,77 @@ defmodule Swag.Processors.SwaggerTest do
   end
 
   describe "#process/3" do
-    test "It takes a swag struct and converts it into a swagger formatted json fragment" do
+    test "Processes config, routes, and schemas into a serialized JSON blob" do
+      config = Swag.Config.new(description: "foo", title: "bar", version: "1")
+
+      schemas = %{
+        User => %{
+          "description" => "User response test"
+        }
+      }
+
+      routes = [
+        %Route{
+          description: "It does a thing",
+          path: "/foo",
+          verb: :get,
+          responses: %{
+            200 => User,
+            201 => :ok
+          }
+        }
+      ]
+
+      assert Swagger.process(config, routes, schemas) ==
+               Jason.encode!(%{
+                 "openapi" => "3.0.0",
+                 "info" => %{
+                   "title" => config.title,
+                   "description" => config.description,
+                   "version" => config.version
+                 },
+                 "paths" => [
+                   %{
+                     "/foo" => %{
+                       "get" => %{
+                         "description" => "It does a thing",
+                         "responses" => %{
+                           200 => "#/components/schemas/User",
+                           201 => :ok
+                         }
+                       }
+                     }
+                   }
+                 ],
+                 "components" => %{
+                   "schemas" => %{
+                     "User" => %{
+                       "description" => "User response test"
+                     }
+                   }
+                 }
+               })
+    end
+  end
+
+  describe "#process_headers/1" do
+    test "It returns a map of top-level metadata" do
+      config = Swag.Config.new(description: "foo", title: "bar", version: "1")
+      headers = Swagger.process_headers(config)
+
+      assert headers == %{
+               "openapi" => "3.0.0",
+               "info" => %{
+                 "title" => config.title,
+                 "description" => config.description,
+                 "version" => config.version
+               }
+             }
+    end
+  end
+
+  describe "#process_routes/2" do
+    test "It takes a list of swag routes and schemas and returns a formatted map" do
       schemas = %{
         User => %{
           "description" => "User response test"
@@ -24,61 +95,61 @@ defmodule Swag.Processors.SwaggerTest do
         }
       }
 
-      swag = %Swag{
-        description: "It does a thing",
-        responses: %{
-          200 => User,
-          201 => :ok,
-          203 => "moved permanently",
-          123 => %{"hello" => "world"},
-          404 => NotFound
+      routes = [
+        %Route{
+          description: "It does a thing",
+          responses: %{
+            200 => User,
+            201 => :ok,
+            203 => "moved permanently",
+            123 => %{"hello" => "world"},
+            404 => NotFound
+          },
+          path: "/foo",
+          verb: :get
+        }
+      ]
+
+      processed = Swagger.process_routes(routes, schemas)
+
+      assert processed == [
+               %{
+                 "/foo" => %{
+                   get: %{
+                     "description" => "It does a thing",
+                     "responses" => %{
+                       200 => "#/components/schemas/User",
+                       201 => :ok,
+                       203 => "moved permanently",
+                       123 => %{"hello" => "world"},
+                       404 => "#/components/schemas/NotFound"
+                     }
+                   }
+                 }
+               }
+             ]
+    end
+  end
+
+  describe "#process_schemas/1" do
+    test "It processes the schemas" do
+      schemas = %{
+        User => %{
+          "description" => "User response test"
         },
-        path: "/foo",
-        verb: :get
+        NotFound => %{
+          "description" => "Not found response test"
+        }
       }
 
-      actual = Swagger.process(swag, schemas, %{})
-
-      expected =
-        Jason.encode!(%{
-          "/foo" => %{
-            "get" => %{
-              "description" => "It does a thing",
-              "responses" => %{
-                200 => "#/components/schemas/User",
-                201 => :ok,
-                203 => "moved permanently",
-                123 => %{"hello" => "world"},
-                404 => "#/components/schemas/NotFound"
-              }
-            }
-          }
-        })
-
-      assert actual == expected
-    end
-  end
-
-  describe "#init/1" do
-    test "It returns a json fragment of things that should be written once and sets the open api version" do
-      config = Swag.Config.new(description: "foo", title: "bar", version: "1")
-
-      assert Swagger.init(config) == """
-             {\"info\":{
-               \"description\":\"foo\",
-               \"title\":\"bar\",
-               \"version\":\"1\"},
-             \"openapi\":\"3.0.0\",
-             \"paths\":[
-             """
-    end
-  end
-
-  describe "#finalize/1" do
-    test "It closes the json fragment" do
-      assert Swagger.finalize(:any) == """
-             ]}
-             """
+      assert Swagger.process_schemas(schemas) == %{
+               "User" => %{
+                 "description" => "User response test"
+               },
+               "NotFound" => %{
+                 "description" => "Not found response test"
+               }
+             }
     end
   end
 end

--- a/test/swag/route_test.exs
+++ b/test/swag/route_test.exs
@@ -1,0 +1,86 @@
+defmodule Swag.RouteTest do
+  use ExUnit.Case
+
+  alias Swag.{Config, Route, PipeThroughMap}
+
+  describe "#new/3" do
+    test "It takes elixir documentation and returns a Swag struct" do
+      doc =
+        {{:function, :index, 2}, 8, ["index(conn, _)"], %{"en" => "It ensures the app is alive"},
+         %{headers: %{}}}
+
+      actual = Route.new(doc, Config.new())
+
+      expected = %Route{
+        description: "It ensures the app is alive"
+      }
+
+      assert actual == expected
+    end
+
+    test "The documentation attributes takes priority" do
+      doc =
+        {{:function, :index, 2}, 8, ["index(conn, _)"], %{"en" => "It ensures the app is alive"},
+         %{headers: %{foo: :baz}}}
+
+      actual = Route.new(doc, Config.new(), headers: %{foo: :bar})
+
+      expected = %Route{
+        description: "It ensures the app is alive",
+        headers: %{foo: :baz}
+      }
+
+      assert actual == expected
+    end
+
+    test "The keys will merge if possible" do
+      doc =
+        {{:function, :index, 2}, 8, ["index(conn, _)"], %{"en" => "It ensures the app is alive"},
+         %{headers: %{bar: :baz}}}
+
+      actual = Route.new(doc, Config.new(), headers: %{foo: :bar})
+
+      expected = %Route{
+        description: "It ensures the app is alive",
+        headers: %{foo: :bar, bar: :baz}
+      }
+
+      assert actual == expected
+    end
+  end
+
+  describe "#pipe_through_mapping/2" do
+    test "It grabs takes the pipe through and returns a map" do
+      config =
+        Config.new(
+          pipe_through_mapping: %{
+            api: %{headers: %{foo: :bar}}
+          }
+        )
+
+      actual = Route.pipe_through_mapping(:api, config)
+      expected = PipeThroughMap.new(%{headers: %{foo: :bar}})
+
+      assert actual == expected
+    end
+
+    test "It works with multiple pipe throughs" do
+      config =
+        Config.new(
+          pipe_through_mapping: %{
+            api: %{headers: %{foo: :bar}},
+            auth: %{headers: %{authorization: :bar}}
+          }
+        )
+
+      actual = Route.pipe_through_mapping([:api, :auth], config)
+      expected = PipeThroughMap.new(%{headers: %{foo: :bar, authorization: :bar}})
+
+      assert actual == expected
+    end
+
+    test "It returns an empty map when given nil" do
+      assert Route.pipe_through_mapping(nil, Config.new()) == PipeThroughMap.new()
+    end
+  end
+end

--- a/test/swag_test.exs
+++ b/test/swag_test.exs
@@ -2,7 +2,7 @@ defmodule SwagTest do
   use ExUnit.Case
   doctest Swag
 
-  alias Swag.{Config, PipeThroughMap}
+  alias Swag.Route
 
   defmodule User do
     def to_json_schema() do
@@ -28,17 +28,18 @@ defmodule SwagTest do
     end
   end
 
-  describe "#generate_schema_refs/2" do
-    def generate_helper(swags) do
-      swags
-      |> Flow.from_enumerable()
-      |> Flow.reduce(fn -> %{} end, &Swag.generate_schema_refs/2)
-      |> Map.new()
-    end
+  describe "#generate_documentation/1" do
+    # TODO
+  end
 
+  describe "#generate_routes/1" do
+    # TODO
+  end
+
+  describe "#generate_schemas/1" do
     test "Generates multiple schemas from multiple response types" do
-      swags = [
-        %Swag{
+      routes = [
+        %Route{
           responses: %{
             200 => User,
             404 => NotFound
@@ -47,7 +48,7 @@ defmodule SwagTest do
       ]
 
       assert(
-        generate_helper(swags) == %{
+        Swag.generate_schemas(routes) == %{
           User => %{
             "description" => "User response test"
           },
@@ -59,14 +60,14 @@ defmodule SwagTest do
     end
 
     test "Does not duplicate schemas" do
-      swags = [
-        %Swag{
+      routes = [
+        %Route{
           responses: %{
             200 => User,
             404 => NotFound
           }
         },
-        %Swag{
+        %Route{
           responses: %{
             200 => Comment,
             404 => NotFound
@@ -75,7 +76,7 @@ defmodule SwagTest do
       ]
 
       assert(
-        generate_helper(swags) == %{
+        Swag.generate_schemas(routes) == %{
           User => %{
             "description" => "User response test"
           },
@@ -90,8 +91,8 @@ defmodule SwagTest do
     end
 
     test "Handles non-generated schemas" do
-      swags = [
-        %Swag{
+      routes = [
+        %Route{
           responses: %{
             200 => User,
             201 => :ok,
@@ -103,7 +104,7 @@ defmodule SwagTest do
       ]
 
       assert(
-        generate_helper(swags) == %{
+        Swag.generate_schemas(routes) == %{
           User => %{
             "description" => "User response test"
           },
@@ -115,87 +116,7 @@ defmodule SwagTest do
     end
   end
 
-  describe "#find_action/2" do
-  end
-
-  describe "#new/3" do
-    test "It takes elixir documentation and returns a Swag struct" do
-      doc =
-        {{:function, :index, 2}, 8, ["index(conn, _)"], %{"en" => "It ensures the app is alive"},
-         %{headers: %{}}}
-
-      actual = Swag.new(doc, Config.new())
-
-      expected = %Swag{
-        description: "It ensures the app is alive"
-      }
-
-      assert actual == expected
-    end
-
-    test "The documentation attributes takes priority" do
-      doc =
-        {{:function, :index, 2}, 8, ["index(conn, _)"], %{"en" => "It ensures the app is alive"},
-         %{headers: %{foo: :baz}}}
-
-      actual = Swag.new(doc, Config.new(), headers: %{foo: :bar})
-
-      expected = %Swag{
-        description: "It ensures the app is alive",
-        headers: %{foo: :baz}
-      }
-
-      assert actual == expected
-    end
-
-    test "The keys will merge if possible" do
-      doc =
-        {{:function, :index, 2}, 8, ["index(conn, _)"], %{"en" => "It ensures the app is alive"},
-         %{headers: %{bar: :baz}}}
-
-      actual = Swag.new(doc, Config.new(), headers: %{foo: :bar})
-
-      expected = %Swag{
-        description: "It ensures the app is alive",
-        headers: %{foo: :bar, bar: :baz}
-      }
-
-      assert actual == expected
-    end
-  end
-
-  describe "#pipe_through_mapping/2" do
-    test "It grabs takes the pipe through and returns a map" do
-      config =
-        Config.new(
-          pipe_through_mapping: %{
-            api: %{headers: %{foo: :bar}}
-          }
-        )
-
-      actual = Swag.pipe_through_mapping(:api, config)
-      expected = PipeThroughMap.new(%{headers: %{foo: :bar}})
-
-      assert actual == expected
-    end
-
-    test "It works with multiple pipe throughs" do
-      config =
-        Config.new(
-          pipe_through_mapping: %{
-            api: %{headers: %{foo: :bar}},
-            auth: %{headers: %{authorization: :bar}}
-          }
-        )
-
-      actual = Swag.pipe_through_mapping([:api, :auth], config)
-      expected = PipeThroughMap.new(%{headers: %{foo: :bar, authorization: :bar}})
-
-      assert actual == expected
-    end
-
-    test "It returns an empty map when given nil" do
-      assert Swag.pipe_through_mapping(nil, Config.new()) == PipeThroughMap.new()
-    end
+  describe "#write/2" do
+    # TODO
   end
 end


### PR DESCRIPTION
# [PLATFORM-374](https://frame-io.atlassian.net/browse/PLATFORM-374)

This involved restructuring the `Swag.Processor` behaviour to be run via a single `#process/3` function, which coordinates collecting the various parts and stitching them together into the final, encoded JSON.

Also:

- Pull out parts of top-level `Swag` module into `Swag.Route`
- Restructuring remaining `Swag` pieces and adding typespecs