### PR TITLE
feat(RouteFiltering): Updates to support route filtering

### DIFF
--- a/lib/rolodex.ex
+++ b/lib/rolodex.ex
@@ -202,23 +202,15 @@ defmodule Rolodex do
 
   @doc """
   Inspects the Phoenix Router provided in your `Rolodex.Config`. Iterates
-  through the list of routes to generate a `Rolodex.Route` for each.
-
-  If you have a `filter` set in your config, it will filter out any routes that
-  match the filter.
+  through the list of routes to generate a `Rolodex.Route` for each. It will
+  filter out any route(s) that match the filter(s) you provide in your config.
   """
   @spec generate_routes(Rolodex.Config.t()) :: [Rolodex.Route.t()]
   def generate_routes(%Config{router: router} = config) do
     router.__routes__()
     |> Flow.from_enumerable()
     |> Flow.map(&Route.new(&1, config))
-    |> Flow.reject(fn route ->
-      case config.filter do
-        :none -> false
-        # TODO(billyc): Need to rework/improve filtering i think...
-        filter -> route == filter
-      end
-    end)
+    |> Flow.reject(&Route.matches_filter?(&1, config))
     |> Enum.to_list()
   end
 

--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -11,7 +11,9 @@ defmodule Rolodex.Config do
   - `router` (required) - `Phoenix.Router` module to inspect
   - `title` (required) - Title for your documentation output
   - `version` (required) - Your documentation's version
-  - `filter` (default: `:none`) - TODO
+  - `filters` (default: `:none`) - A list of maps or functions used to filter
+  out routes from your documentation. Filters are matched against `Rolodex.Route`
+  structs in `Rolodex.Route.matches_filter?/2`.
   - `locale` (default: `"en"`) - Locale key to use when processing descriptions
   - `pipelines` (default: `%{}`) - Map of pipeline configs. Used to set default
   parameter values for all routes in a pipeline. See `Rolodex.PipelineConfig`.
@@ -55,7 +57,7 @@ defmodule Rolodex.Config do
     :router,
     :title,
     :version,
-    filter: :none,
+    filters: :none,
     locale: "en",
     pipelines: %{},
     processor: Rolodex.Processors.Swagger,
@@ -67,7 +69,7 @@ defmodule Rolodex.Config do
 
   @type t :: %__MODULE__{
           description: binary(),
-          filter: keyword() | :none,
+          filters: [map() | (Rolodex.Route.t() -> boolean())] | :none,
           locale: binary(),
           pipelines: pipeline_configs() | nil,
           processor: module(),

--- a/lib/rolodex/route.ex
+++ b/lib/rolodex/route.ex
@@ -339,10 +339,32 @@ defmodule Rolodex.Route do
         }
 
   @doc """
+  Checks to see if the given route matches any filter(s) stored in `Rolodex.Config`.
+  """
+  @spec matches_filter?(t(), Rolodex.Config.t()) :: boolean()
+  def matches_filter?(route, config)
+
+  def matches_filter?(route, %Config{filters: filters}) when is_list(filters) do
+    Enum.any?(filters, fn
+      filter_opts when is_map(filter_opts) ->
+        keys = Map.keys(filter_opts)
+        Map.take(route, keys) == filter_opts
+
+      filter_fun when is_function(filter_fun) ->
+        filter_fun.(route)
+
+      _ ->
+        false
+    end)
+  end
+
+  def matches_filter?(_, _), do: false
+
+  @doc """
   Looks up a `Phoenix.Router.Route` controller action function, parses any
   doc annotations, and returns as a struct.
   """
-  @spec new(Phoenix.Router.Route.t(), Rolodex.Config.t()) :: Rolodex.Route.t()
+  @spec new(Phoenix.Router.Route.t(), Rolodex.Config.t()) :: t()
   def new(phoenix_route, config) do
     action_doc_data = fetch_route_docs(phoenix_route, config)
     pipeline_config = fetch_pipeline_config(phoenix_route, config)

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -2,9 +2,55 @@ defmodule Rolodex.RouteTest do
   use ExUnit.Case
 
   alias Phoenix.Router
-  alias Rolodex.Mocks.{TestController, User}
+  alias Rolodex.Mocks.{TestController, TestRouter, User}
 
   alias Rolodex.{Config, Route}
+
+  describe "#matches_filter?/2" do
+    setup [:setup_config]
+
+    test "Always returns false when no filters provided", %{config: config} do
+      routes =
+        TestRouter.__routes__()
+        |> Enum.map(&Route.new(&1, config))
+
+      assert routes |> Enum.at(0) |> Route.matches_filter?(config) == false
+      assert routes |> Enum.at(1) |> Route.matches_filter?(config) == false
+    end
+
+    test "Returns true when for a route that matches a filter map", %{config: config} do
+      config = %Config{config | filters: [%{path: "/api/demo", verb: :get}]}
+
+      routes =
+        TestRouter.__routes__()
+        |> Enum.map(&Route.new(&1, config))
+
+      assert routes |> Enum.at(0) |> Route.matches_filter?(config) == true
+      assert routes |> Enum.at(1) |> Route.matches_filter?(config) == false
+    end
+
+    test "Returns true for a route that matches a filter function", %{config: config} do
+      config = %Config{
+        config
+        | filters: [
+            fn
+              %Route{path: "/api/demo/:id", verb: :post} ->
+                true
+
+              _ ->
+                false
+            end
+          ]
+      }
+
+      routes =
+        TestRouter.__routes__()
+        |> Enum.map(&Route.new(&1, config))
+
+      assert routes |> Enum.at(0) |> Route.matches_filter?(config) == false
+      assert routes |> Enum.at(1) |> Route.matches_filter?(config) == true
+    end
+  end
 
   describe "#new/2" do
     setup [:setup_config]

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -19,7 +19,13 @@ defmodule RolodexTest do
 
   describe "#run/1" do
     test "Generates documentation and writes out to destination" do
-      config = Config.new(router: TestRouter, writer: %{module: Rolodex.Writers.Mock})
+      config =
+        Config.new(
+          router: TestRouter,
+          filters: [%{path: "/api/demo/:id", verb: :delete}],
+          writer: %{module: Rolodex.Writers.Mock}
+        )
+
       result = capture_io(fn -> Rolodex.run(config) end) |> Jason.decode!()
 
       assert result == %{
@@ -262,6 +268,15 @@ defmodule RolodexTest do
                path: "/api/demo/:id",
                verb: :post
              }
+    end
+
+    test "It filters out routes that match the config" do
+      num_routes =
+        Config.new(router: TestRouter, filters: [%{path: "/api/demo/:id", verb: :delete}])
+        |> Rolodex.generate_routes()
+        |> length()
+
+      assert num_routes == 2
     end
   end
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -4,6 +4,7 @@ defmodule Rolodex.Mocks.TestRouter do
   scope "/api", Rolodex.Mocks do
     get("/demo", TestController, :index)
     post("/demo/:id", TestController, :conflicted)
+    delete("/demo/:id", TestController, :undocumented)
   end
 end
 


### PR DESCRIPTION
## [PLATFORM-397](https://frame-io.atlassian.net/browse/PLATFORM-397)

Allows users to filter out routes from the documentation output. Filters are defined in the Rolodex config and can be either a map of match metadata or a match function. Match checks are done in `Rolodex.Route.matches_filter?/2`.