### PR TITLE
MVP Cleanup

### DIFF
--- a/lib/mix/tasks/rolodex.ex
+++ b/lib/mix/tasks/rolodex.ex
@@ -1,0 +1,17 @@
+defmodule Mix.Tasks.Rolodex do
+  use Mix.Task
+
+  @shortdoc "Prints Rolodex help information"
+
+  @moduledoc """
+  Prints all available Rolodex tasks.
+
+      mix rolodex
+  """
+
+  @doc false
+  def run(_args) do
+    Mix.shell().info("\nAvailable Rolodex Tasks:\n")
+    Mix.Tasks.Help.run(["--search", "rolodex."])
+  end
+end

--- a/lib/mix/tasks/rolodex.gen.docs.ex
+++ b/lib/mix/tasks/rolodex.gen.docs.ex
@@ -1,6 +1,9 @@
-defmodule Mix.Tasks.GenDocs do
+defmodule Mix.Tasks.Rolodex.Gen.Docs do
   use Mix.Task
 
+  @shortdoc "Runs Rolodex to generate API docs."
+
+  @doc false
   def run(_args) do
     Application.get_all_env(:rolodex)
     |> Rolodex.Config.new()

--- a/lib/rolodex.ex
+++ b/lib/rolodex.ex
@@ -184,7 +184,9 @@ defmodule Rolodex do
          :ok <- writer.close(device) do
       :ok
     else
-      err -> err
+      err ->
+        IO.puts("Failed to write docs with error:")
+        IO.inspect(err)
     end
   end
 
@@ -210,7 +212,7 @@ defmodule Rolodex do
     router.__routes__()
     |> Flow.from_enumerable()
     |> Flow.map(&Route.new(&1, config))
-    |> Flow.reject(&Route.matches_filter?(&1, config))
+    |> Flow.reject(&(&1 == nil || Route.matches_filter?(&1, config)))
     |> Enum.to_list()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Rolodex.MixProject do
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
+      dialyzer: [plt_add_apps: [:mix]],
       deps: deps(),
       package: package()
     ]

--- a/test/rolodex/config_test.exs
+++ b/test/rolodex/config_test.exs
@@ -1,0 +1,34 @@
+defmodule Rolodex.ConfigTest do
+  use ExUnit.Case
+
+  alias Rolodex.{Config, PipelineConfig, WriterConfig}
+
+  describe "#new/1" do
+    test "It parses nested writer config into a struct to set defaults" do
+      default_config = Config.new()
+      default_writer_config = WriterConfig.new()
+
+      assert match?(%Config{writer: ^default_writer_config}, default_config)
+
+      config = Config.new(writer: [file_name: "testing.json"])
+      writer_config = WriterConfig.new(file_name: "testing.json")
+
+      assert match?(%Config{writer: ^writer_config}, config)
+    end
+
+    test "It parses pipeline configs into structs to set defaults" do
+      config =
+        Config.new(
+          pipelines: [
+            api: [
+              body: [
+                id: :uuid
+              ]
+            ]
+          ]
+        )
+
+      assert match?(%Config{pipelines: %{api: %PipelineConfig{body: %{id: :uuid}}}}, config)
+    end
+  end
+end

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -211,6 +211,18 @@ defmodule Rolodex.RouteTest do
                verb: :post
              }
     end
+
+    test "It handles a missing controller action" do
+      phoenix_route = %Router.Route{
+        plug: TestController,
+        opts: :does_not_exist,
+        path: "/v2/test",
+        pipe_through: [],
+        verb: :post
+      }
+
+      assert Route.new(phoenix_route, Config.new()) == nil
+    end
   end
 
   def setup_config(_) do

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -5,6 +5,9 @@ defmodule Rolodex.Mocks.TestRouter do
     get("/demo", TestController, :index)
     post("/demo/:id", TestController, :conflicted)
     delete("/demo/:id", TestController, :undocumented)
+
+    # This route action does not exist
+    put("/demo/:id", TestController, :missing_action)
   end
 end
 


### PR DESCRIPTION
## [PLATFORM-396](https://frame-io.atlassian.net/browse/PLATFORM-396)

Various pieces of cleanup ahead of MVP and to ensure things work as expected for our own API docs use cases.

- Handle missing controller action methods
- Restructure the mix tasks
- Nested config parsing for writer and pipelines