### PR TITLE
feat(ServerURLs): Specify shared base URLs for API paths

### DIFF
--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -19,6 +19,7 @@ defmodule Rolodex.Config do
   parameter values for all routes in a pipeline. See `Rolodex.PipelineConfig`.
   - `processor` (default: `Rolodex.Processors.Swagger`) - Module implementing
   the `Rolodex.Processor` behaviour
+  - `server_urls` (default: []) - List of base url(s) for your API paths
   - `writer` (default: `Rolodex.WriterConfig.t()`) - Destination
   for writing and a module implementing the `Rolodex.Writer` behaviour
 
@@ -63,7 +64,8 @@ defmodule Rolodex.Config do
     :writer,
     filters: :none,
     locale: "en",
-    processor: Rolodex.Processors.Swagger
+    processor: Rolodex.Processors.Swagger,
+    server_urls: []
   ]
 
   @type t :: %__MODULE__{
@@ -73,6 +75,7 @@ defmodule Rolodex.Config do
           pipelines: pipeline_configs() | nil,
           processor: module(),
           router: module(),
+          server_urls: [binary()],
           title: binary(),
           version: binary(),
           writer: WriterConfig.t()

--- a/lib/rolodex/processors/swagger.ex
+++ b/lib/rolodex/processors/swagger.ex
@@ -10,7 +10,7 @@ defmodule Rolodex.Processors.Swagger do
     :type
   ]
 
-  alias Rolodex.Route
+  alias Rolodex.{Config, Route}
 
   @impl Rolodex.Processor
   def process(config, routes, schemas) do
@@ -31,13 +31,18 @@ defmodule Rolodex.Processors.Swagger do
   @impl Rolodex.Processor
   def process_headers(config) do
     %{
-      "openapi" => @open_api_version,
-      "info" => %{
-        "title" => config.title,
-        "description" => config.description,
-        "version" => config.version
+      openapi: @open_api_version,
+      servers: process_server_urls(config),
+      info: %{
+        title: config.title,
+        description: config.description,
+        version: config.version
       }
     }
+  end
+
+  defp process_server_urls(%Config{server_urls: urls}) do
+    for url <- urls, do: %{url: url}
   end
 
   @impl Rolodex.Processor

--- a/test/rolodex/processors/swagger_test.exs
+++ b/test/rolodex/processors/swagger_test.exs
@@ -1,13 +1,20 @@
 defmodule Rolodex.Processors.SwaggerTest do
   use ExUnit.Case
 
-  alias Rolodex.{Route, Schema}
+  alias Rolodex.{Config, Route, Schema}
   alias Rolodex.Processors.Swagger
   alias Rolodex.Mocks.{User, NotFound}
 
   describe "#process/3" do
     test "Processes config, routes, and schemas into a serialized JSON blob" do
-      config = Rolodex.Config.new(description: "foo", title: "bar", version: "1")
+      config =
+        Config.new(
+          description: "foo",
+          title: "bar",
+          version: "1",
+          server_urls: ["https://api.example.com"]
+        )
+
       schemas = %{User => Schema.to_map(User)}
 
       routes = [
@@ -37,6 +44,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                  "description" => config.description,
                  "version" => config.version
                },
+               "servers" => [%{"url" => "https://api.example.com"}],
                "paths" => %{
                  "/foo" => %{
                    "get" => %{
@@ -125,15 +133,23 @@ defmodule Rolodex.Processors.SwaggerTest do
 
   describe "#process_headers/1" do
     test "It returns a map of top-level metadata" do
-      config = Rolodex.Config.new(description: "foo", title: "bar", version: "1")
+      config =
+        Config.new(
+          description: "foo",
+          title: "bar",
+          version: "1",
+          server_urls: ["https://api.example.com"]
+        )
+
       headers = Swagger.process_headers(config)
 
       assert headers == %{
-               "openapi" => "3.0.0",
-               "info" => %{
-                 "title" => config.title,
-                 "description" => config.description,
-                 "version" => config.version
+               openapi: "3.0.0",
+               servers: [%{url: "https://api.example.com"}],
+               info: %{
+                 title: config.title,
+                 description: config.description,
+                 version: config.version
                }
              }
     end

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -23,7 +23,8 @@ defmodule RolodexTest do
         Config.new(
           router: TestRouter,
           filters: [%{path: "/api/demo/:id", verb: :delete}],
-          writer: %{module: Rolodex.Writers.Mock}
+          writer: %{module: Rolodex.Writers.Mock},
+          server_urls: ["https://api.example.com"]
         )
 
       result = capture_io(fn -> Rolodex.run(config) end) |> Jason.decode!()
@@ -90,6 +91,7 @@ defmodule RolodexTest do
                },
                "info" => %{"description" => nil, "title" => nil, "version" => nil},
                "openapi" => "3.0.0",
+               "servers" => [%{"url" => "https://api.example.com"}],
                "paths" => %{
                  "/api/demo" => %{
                    "get" => %{


### PR DESCRIPTION
## [PLATFORM-401](https://frame-io.atlassian.net/browse/PLATFORM-401)

See: https://swagger.io/docs/specification/api-host-and-base-path/