### PR TITLE
Field and config metadata updates

### DIFF
--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -141,26 +141,30 @@ defmodule Rolodex.PipelineConfig do
   - `headers` (default: `%{}`)
   - `path_params` (default: `%{}`)
   - `query_params` (default: `%{}`)
+  - `responses` (default: `%{}`)
 
   ## Example
 
       %Rolodex.PipelineConfig{
         body: %{id: :uuid, name: :string}
         headers: %{"X-Request-Id" => :uuid},
-        query_params: %{account_id: :uuid}
+        query_params: %{account_id: :uuid},
+        responses: %{401 => SharedUnauthorizedResponse}
       }
   """
 
   defstruct body: %{},
             headers: %{},
             path_params: %{},
-            query_params: %{}
+            query_params: %{},
+            responses: %{}
 
   @type t :: %__MODULE__{
           body: map(),
           headers: map(),
           path_params: map(),
-          query_params: map()
+          query_params: map(),
+          responses: map()
         }
 
   @spec new(list() | map()) :: t()

--- a/lib/rolodex/route.ex
+++ b/lib/rolodex/route.ex
@@ -289,6 +289,7 @@ defmodule Rolodex.Route do
 
   alias Rolodex.{
     Config,
+    PipelineConfig,
     Schema
   }
 
@@ -432,7 +433,7 @@ defmodule Rolodex.Route do
     Enum.reduce(pipe_through, %{}, fn pt, acc ->
       pipeline_config =
         pipelines
-        |> Map.get(pt, %{})
+        |> Map.get(pt, %PipelineConfig{})
         |> Map.from_struct()
         |> parse_param_fields()
 

--- a/lib/rolodex/schema.ex
+++ b/lib/rolodex/schema.ex
@@ -237,13 +237,23 @@ defmodule Rolodex.Schema do
 
   ### Parsing primitive data types (e.g. `string`)
 
+  Valid options for a primitive are:
+
+  - `enum` - a list of possible values
+  - `desc`
+  - `default`
+  - `format`
+  - `maximum`
+  - `minimum`
+  - `required`
+
       # Creating a simple field with a primitive type
       iex> Rolodex.Schema.new_field(:string)
       %{type: :string}
 
       # With additional options
-      iex> Rolodex.Schema.new_field(type: :string, desc: "My string")
-      %{type: :string, desc: "My string"}
+      iex> Rolodex.Schema.new_field(type: :string, desc: "My string", enum: ["foo", "bar"])
+      %{type: :string, desc: "My string", enum: ["foo", "bar"]}
 
   ### Parsing collections: objects and lists
 

--- a/test/rolodex/processors/swagger_test.exs
+++ b/test/rolodex/processors/swagger_test.exs
@@ -85,10 +85,17 @@ defmodule Rolodex.Processors.SwaggerTest do
                  "schemas" => %{
                    "User" => %{
                      "type" => "object",
+                     "description" => "A user record",
+                     "required" => ["id", "email"],
                      "properties" => %{
-                       "id" => %{"type" => "string", "format" => "uuid"},
+                       "id" => %{
+                         "type" => "string",
+                         "format" => "uuid",
+                         "description" => "The id of the user"
+                       },
                        "email" => %{
-                         "type" => "string"
+                         "type" => "string",
+                         "description" => "The email of the user"
                        },
                        "comment" => %{
                          "$ref" => "#/components/schemas/Comment"
@@ -101,6 +108,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                        },
                        "comments_of_many_types" => %{
                          "type" => "array",
+                         "description" => "List of text or comment",
                          "items" => %{
                            "oneOf" => [
                              %{
@@ -180,7 +188,7 @@ defmodule Rolodex.Processors.SwaggerTest do
             update: %{type: :boolean}
           },
           path_params: %{
-            account_id: %{type: :uuid}
+            account_id: %{type: :uuid, desc: "The account id"}
           },
           responses: %{
             200 => %{type: :ref, ref: User},
@@ -202,7 +210,6 @@ defmodule Rolodex.Processors.SwaggerTest do
                      %{
                        in: :header,
                        name: "X-Request-Id",
-                       description: "",
                        required: true,
                        schema: %{
                          type: :string,
@@ -212,17 +219,15 @@ defmodule Rolodex.Processors.SwaggerTest do
                      %{
                        in: :path,
                        name: :account_id,
-                       description: "",
-                       required: false,
                        schema: %{
                          type: :string,
-                         format: :uuid
+                         format: :uuid,
+                         description: "The account id"
                        }
                      },
                      %{
                        in: :query,
                        name: :id,
-                       description: "",
                        required: true,
                        schema: %{
                          type: :integer,
@@ -234,8 +239,6 @@ defmodule Rolodex.Processors.SwaggerTest do
                      %{
                        in: :query,
                        name: :update,
-                       description: "",
-                       required: false,
                        schema: %{
                          type: :boolean
                        }
@@ -370,10 +373,17 @@ defmodule Rolodex.Processors.SwaggerTest do
       assert Swagger.process_schemas(schemas) == %{
                "User" => %{
                  type: :object,
+                 description: "A user record",
+                 required: [:id, :email],
                  properties: %{
-                   id: %{type: :string, format: :uuid},
+                   id: %{
+                     type: :string,
+                     format: :uuid,
+                     description: "The id of the user"
+                   },
                    email: %{
-                     type: :string
+                     type: :string,
+                     description: "The email of the user"
                    },
                    comment: %{
                      "$ref" => "#/components/schemas/Comment"
@@ -386,6 +396,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                    },
                    comments_of_many_types: %{
                      type: :array,
+                     description: "List of text or comment",
                      items: %{
                        oneOf: [
                          %{
@@ -412,6 +423,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                },
                "NotFound" => %{
                  type: :object,
+                 description: "Not found response",
                  properties: %{
                    message: %{
                      type: :string

--- a/test/rolodex/schema_test.exs
+++ b/test/rolodex/schema_test.exs
@@ -31,9 +31,11 @@ defmodule Rolodex.SchemaTest do
 
   describe "#field/3 macro" do
     test "It generates getters" do
-      assert User.__field__(:id) == {:id, %{type: :uuid, desc: "The id of the user"}}
+      assert User.__field__(:id) ==
+               {:id, %{type: :uuid, desc: "The id of the user", required: true}}
 
-      assert User.__field__(:email) == {:email, %{type: :string, desc: "The email of the user"}}
+      assert User.__field__(:email) ==
+               {:email, %{type: :string, desc: "The email of the user", required: true}}
 
       assert User.__field__(:comment) == {:comment, %{type: :ref, ref: Comment}}
       assert User.__field__(:parent) == {:parent, %{type: :ref, ref: Parent}}
@@ -70,8 +72,8 @@ defmodule Rolodex.SchemaTest do
                type: :object,
                desc: "A user record",
                properties: %{
-                 id: %{desc: "The id of the user", type: :uuid},
-                 email: %{desc: "The email of the user", type: :string},
+                 id: %{desc: "The id of the user", type: :uuid, required: true},
+                 email: %{desc: "The email of the user", type: :string, required: true},
                  parent: %{type: :ref, ref: Parent},
                  comment: %{type: :ref, ref: Comment},
                  comments: %{

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -33,8 +33,13 @@ defmodule RolodexTest do
                "components" => %{
                  "schemas" => %{
                    "Comment" => %{
+                     "description" => "A comment record",
                      "properties" => %{
-                       "id" => %{"format" => "uuid", "type" => "string"},
+                       "id" => %{
+                         "format" => "uuid",
+                         "type" => "string",
+                         "description" => "The comment id"
+                       },
                        "text" => %{
                          "type" => "string"
                        }
@@ -42,6 +47,7 @@ defmodule RolodexTest do
                      "type" => "object"
                    },
                    "NotFound" => %{
+                     "description" => "Not found response",
                      "properties" => %{
                        "message" => %{
                          "type" => "string"
@@ -54,27 +60,42 @@ defmodule RolodexTest do
                      "type" => "object"
                    },
                    "User" => %{
+                     "type" => "object",
+                     "description" => "A user record",
+                     "required" => ["id", "email"],
                      "properties" => %{
-                       "comment" => %{"$ref" => "#/components/schemas/Comment"},
+                       "id" => %{
+                         "type" => "string",
+                         "format" => "uuid",
+                         "description" => "The id of the user"
+                       },
+                       "email" => %{
+                         "type" => "string",
+                         "description" => "The email of the user"
+                       },
+                       "comment" => %{
+                         "$ref" => "#/components/schemas/Comment"
+                       },
                        "comments" => %{
-                         "items" => %{"$ref" => "#/components/schemas/Comment"},
-                         "type" => "array"
+                         "type" => "array",
+                         "items" => %{
+                           "$ref" => "#/components/schemas/Comment"
+                         }
                        },
                        "comments_of_many_types" => %{
+                         "type" => "array",
+                         "description" => "List of text or comment",
                          "items" => %{
                            "oneOf" => [
                              %{
                                "type" => "string"
                              },
-                             %{"$ref" => "#/components/schemas/Comment"}
+                             %{
+                               "$ref" => "#/components/schemas/Comment"
+                             }
                            ]
-                         },
-                         "type" => "array"
+                         }
                        },
-                       "email" => %{
-                         "type" => "string"
-                       },
-                       "id" => %{"format" => "uuid", "type" => "string"},
                        "multi" => %{
                          "oneOf" => [
                            %{
@@ -83,9 +104,10 @@ defmodule RolodexTest do
                            %{"$ref" => "#/components/schemas/NotFound"}
                          ]
                        },
-                       "parent" => %{"$ref" => "#/components/schemas/Parent"}
-                     },
-                     "type" => "object"
+                       "parent" => %{
+                         "$ref" => "#/components/schemas/Parent"
+                       }
+                     }
                    }
                  }
                },
@@ -97,24 +119,19 @@ defmodule RolodexTest do
                    "get" => %{
                      "parameters" => [
                        %{
-                         "description" => "",
                          "in" => "header",
                          "name" => "X-Request-Id",
                          "required" => true,
                          "schema" => %{"format" => "uuid", "type" => "string"}
                        },
                        %{
-                         "description" => "",
                          "in" => "path",
                          "name" => "account_id",
-                         "required" => false,
                          "schema" => %{"format" => "uuid", "type" => "string"}
                        },
                        %{
-                         "description" => "",
                          "in" => "query",
                          "name" => "id",
-                         "required" => false,
                          "schema" => %{
                            "default" => 2,
                            "maximum" => 10,
@@ -123,10 +140,8 @@ defmodule RolodexTest do
                          }
                        },
                        %{
-                         "description" => "",
                          "in" => "query",
                          "name" => "update",
-                         "required" => false,
                          "schema" => %{
                            "type" => "boolean"
                          }
@@ -139,7 +154,8 @@ defmodule RolodexTest do
                              "properties" => %{
                                "id" => %{"format" => "uuid", "type" => "string"},
                                "name" => %{
-                                 "type" => "string"
+                                 "type" => "string",
+                                 "description" => "The name"
                                }
                              },
                              "type" => "object"
@@ -192,10 +208,8 @@ defmodule RolodexTest do
                    "post" => %{
                      "parameters" => [
                        %{
-                         "description" => "",
                          "in" => "header",
                          "name" => "X-Request-Id",
-                         "required" => false,
                          "schema" => %{
                            "type" => "string"
                          }
@@ -435,11 +449,13 @@ defmodule RolodexTest do
                    },
                    email: %{
                      desc: "The email of the user",
-                     type: :string
+                     type: :string,
+                     required: true
                    },
                    id: %{
                      desc: "The id of the user",
-                     type: :uuid
+                     type: :uuid,
+                     required: true
                    },
                    multi: %{
                      of: [

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -64,8 +64,8 @@ defmodule Rolodex.Mocks.User do
   use Rolodex.Schema
 
   schema "User", desc: "A user record" do
-    field(:id, :uuid, desc: "The id of the user")
-    field(:email, :string, desc: "The email of the user")
+    field(:id, :uuid, desc: "The id of the user", required: true)
+    field(:email, :string, desc: "The email of the user", required: true)
 
     # Nested object
     field(:comment, Rolodex.Mocks.Comment)


### PR DESCRIPTION
For [PLATFORM-396](https://frame-io.atlassian.net/browse/PLATFORM-396)

1. Add support for an `enum` opt on fields. Should be a list of valid values for the field. In the Swagger processor, we look for this now.
2. Ensure we serialize field descriptions into Swagger JSON.
3. Better support for required fields in Swagger JSON output. For objects, we need to collected all required props into a top-level array.
4. Fix: support shared responses for pipelines via config