### PR TITLE
Rolodex.RequestBody: Define shared request bodies

### DIFF
--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -11,6 +11,8 @@ defmodule Rolodex.Config do
   - `router` (required) - `Phoenix.Router` module to inspect
   - `title` (required) - Title for your documentation output
   - `version` (required) - Your documentation's version
+  - `default_content_type` (default: "application/json") - Default content type
+  used for request body and response schemas
   - `filters` (default: `:none`) - A list of maps or functions used to filter
   out routes from your documentation. Filters are matched against `Rolodex.Route`
   structs in `Rolodex.Route.matches_filter?/2`.
@@ -62,6 +64,7 @@ defmodule Rolodex.Config do
     :title,
     :version,
     :writer,
+    default_content_type: "application/json",
     filters: :none,
     locale: "en",
     processor: Rolodex.Processors.Swagger,
@@ -69,6 +72,7 @@ defmodule Rolodex.Config do
   ]
 
   @type t :: %__MODULE__{
+          default_content_type: binary(),
           description: binary(),
           filters: [map() | (Rolodex.Route.t() -> boolean())] | :none,
           locale: binary(),

--- a/lib/rolodex/content_utils.ex
+++ b/lib/rolodex/content_utils.ex
@@ -1,0 +1,124 @@
+defmodule Rolodex.ContentUtils do
+  @moduledoc false
+
+  alias Rolodex.Field
+
+  def def_content_body(type, name, do: block) do
+    quote do
+      Module.register_attribute(__MODULE__, :content_types, accumulate: true)
+      Module.register_attribute(__MODULE__, :current_content_type, accumulate: false)
+      Module.register_attribute(__MODULE__, :body_description, accumulate: false)
+
+      @body_description nil
+
+      unquote(block)
+
+      Module.delete_attribute(__MODULE__, :current_content_type)
+
+      def unquote(type)(:name), do: unquote(name)
+      def unquote(type)(:desc), do: @body_description
+      def unquote(type)(:content_types), do: @content_types |> Enum.reverse()
+    end
+  end
+
+  def set_desc(str) do
+    quote do
+      @body_description unquote(str)
+    end
+  end
+
+  def def_content_type_shape(type, key, do: block) do
+    quote do
+      Module.register_attribute(__MODULE__, :examples, accumulate: true)
+
+      @content_types unquote(key)
+      @current_content_type unquote(key)
+
+      unquote(block)
+
+      def unquote(type)({unquote(key), :examples}), do: @examples |> Enum.reverse()
+
+      Module.delete_attribute(__MODULE__, :examples)
+    end
+  end
+
+  def set_example(type, name, example_body) do
+    quote do
+      @examples unquote(name)
+
+      def unquote(type)({@current_content_type, :examples, unquote(name)}),
+        do: unquote(example_body)
+    end
+  end
+
+  def set_schema(type, mods) when is_list(mods) do
+    quote do
+      def unquote(type)({@current_content_type, :schema}) do
+        Field.new(type: :list, of: unquote(mods))
+      end
+    end
+  end
+
+  def set_schema(type, mod) do
+    quote do
+      def unquote(type)({@current_content_type, :schema}) do
+        Field.new(unquote(mod))
+      end
+    end
+  end
+
+  def set_schema(type, collection_type, of: mods) do
+    quote do
+      def unquote(type)({@current_content_type, :schema}) do
+        Field.new(type: unquote(collection_type), of: unquote(mods))
+      end
+    end
+  end
+
+  def is_module_of_type?(mod, type) when is_atom(mod) do
+    try do
+      mod.__info__(:functions) |> Keyword.has_key?(type)
+    rescue
+      _ -> false
+    end
+  end
+
+  def is_module_of_type?(_), do: false
+
+  def to_map(fun) do
+    %{
+      desc: fun.(:desc),
+      content: serialize_content(fun)
+    }
+  end
+
+  defp serialize_content(fun) do
+    fun.(:content_types)
+    |> Map.new(fn content_type ->
+      data = %{
+        schema: fun.({content_type, :schema}),
+        examples: serialize_examples(fun, content_type)
+      }
+
+      {content_type, data}
+    end)
+  end
+
+  defp serialize_examples(fun, content_type) do
+    fun.({content_type, :examples})
+    |> Map.new(&{&1, fun.({content_type, :examples, &1})})
+  end
+
+  def get_refs(fun) do
+    fun
+    |> to_map()
+    |> Map.get(:content)
+    |> Enum.reduce(MapSet.new(), fn {_, %{schema: schema}}, acc ->
+      schema
+      |> Field.get_refs()
+      |> MapSet.new()
+      |> MapSet.union(acc)
+    end)
+    |> Enum.to_list()
+  end
+end

--- a/lib/rolodex/processors/processor.ex
+++ b/lib/rolodex/processors/processor.ex
@@ -8,7 +8,7 @@ defmodule Rolodex.Processor do
   processing and returning the formatted string.
   """
 
-  @optional_callbacks process_headers: 1, process_routes: 1, process_refs: 1
+  @optional_callbacks process_headers: 1, process_routes: 2, process_refs: 1
 
   @doc """
   Process is responsible for turning each `Rolodex.Route.t()` it receives and
@@ -26,11 +26,11 @@ defmodule Rolodex.Processor do
   @doc """
   Transforms the routes.
   """
-  @callback process_routes([Rolodex.Route.t()]) :: map()
-  def process_routes(_), do: %{}
+  @callback process_routes([Rolodex.Route.t()], Rolodex.Config.t()) :: map()
+  def process_routes(_, _), do: %{}
 
   @doc """
-  Transforms the shared response and schema refs
+  Transforms the shared request body, response, and schema refs
   """
   @callback process_refs(refs :: map()) :: map()
   def process_refs(_), do: %{}

--- a/lib/rolodex/request_body.ex
+++ b/lib/rolodex/request_body.ex
@@ -1,0 +1,240 @@
+defmodule Rolodex.RequestBody do
+  @moduledoc """
+  Exposes functions and macros for defining reusable request bodies.
+
+  It exposes the following macros, which when used together will setup a request body:
+
+  - `request_body/2` - for declaring a request body
+  - `desc/1` - for setting an (optional) request body description
+  - `content/2` - for defining a request body shape for a specific content type
+  - `schema/1` and `schema/2` - for defining the shape for a content type
+  - `example/2` - for defining an (optional) request body example for a content type
+
+  It also exposes the following functions:
+
+  - `is_request_body_module?/1` - determines if the provided item is a module that
+  has defined a reusable request body
+  - `to_map/1` - serializes a request body module into a map
+  - `get_refs/1` - traverses a request body and searches for any nested
+  `Rolodex.Schema` refs within
+  """
+
+  alias Rolodex.ContentUtils
+
+  defmacro __using__(_opts) do
+    quote do
+      import Rolodex.RequestBody, only: :macros
+    end
+  end
+
+  @doc """
+  Opens up the request body definition for the current module. Will name the
+  request body and generate metadata for the request body based on macro calls
+  within the provided block.
+
+  **Accept**
+  - `name` - the request body name
+  - `block` - request body shape definitions
+
+  ## Example
+
+      defmodule MyRequestBody do
+        use Rolodex.RequestBody
+
+        request_body "MyRequestBody" do
+          desc "A demo request body with multiple content types"
+
+          content "application/json" do
+            schema MyRequestBodySchema
+
+            example :request_body, %{foo: "bar"}
+            example :other_request_body, %{bar: "baz"}
+          end
+
+          content "foo/bar" do
+            schema AnotherRequestBodySchema
+            example :request_body, %{foo: "bar"}
+          end
+        end
+      end
+  """
+  defmacro request_body(name, opts) do
+    ContentUtils.def_content_body(:__request_body__, name, opts)
+  end
+
+  @doc """
+  Sets a description for the request body
+  """
+  defmacro desc(str) do
+    ContentUtils.set_desc(str)
+  end
+
+  @doc """
+  Defines a request body shape for the given content type key
+
+  **Accepts**
+  - `key` - a valid content-type key
+  - `block` - metadata about the request body shape for this content type
+  """
+  defmacro content(key, opts) do
+    ContentUtils.def_content_type_shape(:__request_body__, key, opts)
+  end
+
+  @doc """
+  Sets an example for the content type. This macro can be used multiple times
+  within a content type block to allow multiple examples.
+
+  **Accepts**
+  - `name` - a name for the example
+  - `body` - a map, which is the example data
+  """
+  defmacro example(name, example_body) do
+    ContentUtils.set_example(:__request_body__, name, example_body)
+  end
+
+  @doc """
+  Sets a schema for the current request body content type. Data passed into to
+  the schema/1 macro will be parsed by `Rolodex.Field.new/1`.
+
+  ## Examples
+
+      # Request body is a list, where each item is a MySchema
+      content "application/json" do
+        schema [MySchema]
+      end
+
+      # Request body is a MySchema
+      content "application/json" do
+        content MySchema
+      end
+
+      # Can provide a bare map, which will be parsed via `Rolodex.Field`
+      content "application/json" do
+        schema %{
+          type: :object,
+          properties: %{
+            id: :uuid,
+            name: :string
+          }
+        }
+      end
+  """
+  defmacro schema(mod) do
+    ContentUtils.set_schema(:__request_body__, mod)
+  end
+
+  @doc """
+  Sets a schema of a collection type.
+
+  ## Examples
+
+      # Request body is a list
+      content "application/json" do
+        schema :list, of: [MySchema]
+      end
+
+      # Request body is one of the provided types
+      content "application/json" do
+        schema :one_of, of: [MySchema, MyOtherSchema]
+      end
+  """
+  defmacro schema(collection_type, opts) do
+    ContentUtils.set_schema(:__request_body__, collection_type, opts)
+  end
+
+  @doc """
+  Determines if an arbitrary item is a module that has defined a reusable
+  request body via `Rolodex.RequestBody` macros.
+
+  ## Example
+
+      iex> defmodule SimpleRequestBody do
+      ...>   use Rolodex.RequestBody
+      ...>
+      ...>   request_body "SimpleRequestBody" do
+      ...>     content "application/json" do
+      ...>       schema MySchema
+      ...>     end
+      ...>   end
+      ...> end
+      iex>
+      iex> # Validating a request body module
+      iex> Rolodex.RequestBody.is_request_body_module?(SimpleRequestBody)
+      true
+      iex> # Validating some other module
+      iex> Rolodex.RequestBody.is_request_body_module?(OtherModule)
+      false
+  """
+  @spec is_request_body_module?(any()) :: boolean()
+  def is_request_body_module?(mod), do: ContentUtils.is_module_of_type?(mod, :__request_body__)
+
+  @doc """
+  Serializes the `Rolodex.RequestBody` metadata into a formatted map.
+
+  ## Example
+
+      iex> defmodule MySimpleSchema do
+      ...>   use Rolodex.Schema
+      ...>
+      ...>   schema "MySimpleSchema" do
+      ...>     field :id, :uuid
+      ...>   end
+      ...> end
+      iex>
+      iex> defmodule MyRequestBody do
+      ...>   use Rolodex.RequestBody
+      ...>
+      ...>   request_body "MyRequestBody" do
+      ...>     desc "A demo request body"
+      ...>
+      ...>     content "application/json" do
+      ...>       schema MySimpleSchema
+      ...>       example :request_body, %{id: "123"}
+      ...>     end
+      ...>
+      ...>     content "application/json-list" do
+      ...>       schema [MySimpleSchema]
+      ...>       example :request_body, [%{id: "123"}]
+      ...>       example :another_request_body, [%{id: "234"}]
+      ...>     end
+      ...>   end
+      ...> end
+      iex>
+      iex> Rolodex.RequestBody.to_map(MyRequestBody)
+      %{
+        desc: "A demo request body",
+        content: %{
+          "application/json" => %{
+            examples: %{
+              request_body: %{id: "123"}
+            },
+            schema: %{
+              type: :ref,
+              ref: Rolodex.RequestBodyTest.MySimpleSchema
+            }
+          },
+          "application/json-list" => %{
+            examples: %{
+              request_body: [%{id: "123"}],
+              another_request_body: [%{id: "234"}],
+            },
+            schema: %{
+              type: :list,
+              of: [
+                %{type: :ref, ref: Rolodex.RequestBodyTest.MySimpleSchema}
+              ]
+            }
+          }
+        }
+      }
+  """
+  @spec to_map(module()) :: map()
+  def to_map(mod), do: ContentUtils.to_map(&mod.__request_body__/1)
+
+  @doc """
+  Traverses a serialized Request Body and collects any nested references to any
+  Schemas within. See `Rolodex.Field.get_refs/1` for more info.
+  """
+  @spec get_refs(module()) :: [module()]
+  def get_refs(mod), do: ContentUtils.get_refs(&mod.__request_body__/1)
+end

--- a/lib/rolodex/route.ex
+++ b/lib/rolodex/route.ex
@@ -20,11 +20,14 @@ defmodule Rolodex.Route do
 
   * **`body`** *(Default: `%{}`)
 
-  Request body parameters. Valid inputs: `Rolodex.Schema`, a map, or a list.
+  Request body parameters. Valid inputs: `Rolodex.RequestBody`, or a map or
+  keyword list describing a parameter schema. When providing a plain map or
+  keyword list, the request body schema will be set under the default content
+  type value set in `Rolodex.Config`.
 
       @doc [
-        # A request body defined via a reusable schema
-        body: SomeSchema,
+        # A shared request body defined via `Rolodex.RequestBody`
+        body: SomeRequestBody,
 
         # Request body is a JSON object with two parameters: `id` and `name`
         body: %{id: :uuid, name: :string},

--- a/test/rolodex/field_test.exs
+++ b/test/rolodex/field_test.exs
@@ -11,6 +11,11 @@ defmodule Rolodex.FieldTest do
   doctest Field
 
   describe "new/1" do
+    test "It will return an empty map when an empty map or list is provided" do
+      assert Field.new([]) == %{}
+      assert Field.new(%{}) == %{}
+    end
+
     test "It can create a field" do
       assert Field.new(:string) == %{type: :string}
     end

--- a/test/rolodex/request_body_test.exs
+++ b/test/rolodex/request_body_test.exs
@@ -1,0 +1,127 @@
+defmodule Rolodex.RequestBodyTest do
+  use ExUnit.Case
+
+  alias Rolodex.RequestBody
+
+  alias Rolodex.Mocks.{
+    UserRequestBody,
+    UsersRequestBody,
+    PaginatedUsersRequestBody,
+    ParentsRequestBody,
+    MultiRequestBody,
+    User,
+    Comment,
+    Parent
+  }
+
+  doctest RequestBody
+
+  describe "#request_body/2 macro" do
+    test "It sets the expected getter functions" do
+      assert UserRequestBody.__request_body__(:name) == "UserRequestBody"
+      assert UserRequestBody.__request_body__(:content_types) == ["application/json"]
+    end
+  end
+
+  describe "#desc/1 macro" do
+    test "It sets the expected getter function" do
+      assert UserRequestBody.__request_body__(:desc) == "A single user entity request body"
+    end
+
+    test "Description is not required" do
+      assert MultiRequestBody.__request_body__(:desc) == nil
+    end
+  end
+
+  describe "#content/2 macro" do
+    test "It sets the expected getter function" do
+      assert UserRequestBody.__request_body__({"application/json", :examples}) == [:request]
+    end
+  end
+
+  describe "#example/2 macro" do
+    test "It sets the expected getter function" do
+      assert UserRequestBody.__request_body__({"application/json", :examples, :request}) == %{
+               id: "1"
+             }
+    end
+  end
+
+  describe "#schema/1 macro" do
+    test "It handles a schema module" do
+      assert UserRequestBody.__request_body__({"application/json", :schema}) == %{
+               type: :ref,
+               ref: User
+             }
+    end
+
+    test "It handles a list" do
+      assert UsersRequestBody.__request_body__({"application/json", :schema}) == %{
+               type: :list,
+               of: [%{type: :ref, ref: User}]
+             }
+    end
+
+    test "It handles a bare map" do
+      assert PaginatedUsersRequestBody.__request_body__({"application/json", :schema}) == %{
+               type: :object,
+               properties: %{
+                 total: %{type: :integer},
+                 page: %{type: :integer},
+                 users: %{
+                   type: :list,
+                   of: [%{type: :ref, ref: User}]
+                 }
+               }
+             }
+    end
+  end
+
+  describe "#schema/2 macro" do
+    test "It handles a list" do
+      assert ParentsRequestBody.__request_body__({"application/json", :schema}) == %{
+               type: :list,
+               of: [%{type: :ref, ref: Parent}]
+             }
+    end
+  end
+
+  describe "#is_request_body_module?/2" do
+    test "It detects if the module has defined a request body via the macros" do
+      assert RequestBody.is_request_body_module?(UserRequestBody)
+      assert !RequestBody.is_request_body_module?(User)
+    end
+  end
+
+  describe "#to_map/1" do
+    test "It serializes the request body as expected" do
+      assert RequestBody.to_map(PaginatedUsersRequestBody) == %{
+               desc: "A paginated list of user entities",
+               content: %{
+                 "application/json" => %{
+                   schema: %{
+                     type: :object,
+                     properties: %{
+                       total: %{type: :integer},
+                       page: %{type: :integer},
+                       users: %{
+                         type: :list,
+                         of: [%{type: :ref, ref: User}]
+                       }
+                     }
+                   },
+                   examples: %{
+                     request: [%{id: "1"}]
+                   }
+                 }
+               }
+             }
+    end
+  end
+
+  describe "#get_refs/1" do
+    test "It gets refs within a request body module" do
+      assert RequestBody.get_refs(MultiRequestBody) == [Comment, User]
+    end
+  end
+end

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -1,5 +1,6 @@
 defmodule Rolodex.Mocks.TestController do
   alias Rolodex.Mocks.{
+    UserRequestBody,
     UserResponse,
     PaginatedUsersResponse,
     ErrorResponse
@@ -7,11 +8,6 @@ defmodule Rolodex.Mocks.TestController do
 
   @doc [
     headers: %{"X-Request-Id" => %{type: :uuid, required: true}},
-    # Body is using object shorthand
-    body: %{
-      id: :uuid,
-      name: %{type: :string, desc: "The name"}
-    },
     query_params: %{
       id: %{
         type: :string,
@@ -25,6 +21,7 @@ defmodule Rolodex.Mocks.TestController do
     path_params: %{
       account_id: :uuid
     },
+    body: UserRequestBody,
     responses: %{
       200 => UserResponse,
       201 => PaginatedUsersResponse,
@@ -40,6 +37,14 @@ defmodule Rolodex.Mocks.TestController do
     headers: %{"X-Request-Id" => :string}
   ]
   def conflicted(_, _), do: nil
+
+  @doc [
+    body: %{id: :uuid},
+    responses: %{
+      200 => %{id: :uuid}
+    }
+  ]
+  def with_bare_maps(_, _), do: nil
 
   def undocumented(_, _), do: nil
 end

--- a/test/support/mocks/request_bodies.ex
+++ b/test/support/mocks/request_bodies.ex
@@ -1,0 +1,74 @@
+defmodule Rolodex.Mocks.UserRequestBody do
+  use Rolodex.RequestBody
+  alias Rolodex.Mocks.User
+
+  request_body "UserRequestBody" do
+    desc("A single user entity request body")
+
+    content "application/json" do
+      schema(User)
+      example(:request, %{id: "1"})
+    end
+  end
+end
+
+defmodule Rolodex.Mocks.UsersRequestBody do
+  use Rolodex.RequestBody
+  alias Rolodex.Mocks.User
+
+  request_body "UsersRequestBody" do
+    desc("A list of user entities")
+
+    content "application/json" do
+      schema([User])
+      example(:request, [%{id: "1"}])
+    end
+  end
+end
+
+defmodule Rolodex.Mocks.ParentsRequestBody do
+  use Rolodex.RequestBody
+  alias Rolodex.Mocks.Parent
+
+  request_body "ParentsRequestBody" do
+    desc("A list of parent entities")
+
+    content "application/json" do
+      schema(:list, of: [Parent])
+    end
+  end
+end
+
+defmodule Rolodex.Mocks.PaginatedUsersRequestBody do
+  use Rolodex.RequestBody
+  alias Rolodex.Mocks.User
+
+  request_body "PaginatedUsersRequestBody" do
+    desc("A paginated list of user entities")
+
+    content "application/json" do
+      schema(%{
+        total: :integer,
+        page: :integer,
+        users: [User]
+      })
+
+      example(:request, [%{id: "1"}])
+    end
+  end
+end
+
+defmodule Rolodex.Mocks.MultiRequestBody do
+  use Rolodex.RequestBody
+  alias Rolodex.Mocks.{Comment, User}
+
+  request_body "MultiRequestBody" do
+    content "application/json" do
+      schema(User)
+    end
+
+    content "application/lolsob" do
+      schema([Comment])
+    end
+  end
+end

--- a/test/support/mocks/routers.ex
+++ b/test/support/mocks/routers.ex
@@ -4,6 +4,7 @@ defmodule Rolodex.Mocks.TestRouter do
   scope "/api", Rolodex.Mocks do
     get("/demo", TestController, :index)
     post("/demo/:id", TestController, :conflicted)
+    put("/demo/:id", TestController, :with_bare_maps)
     delete("/demo/:id", TestController, :undocumented)
 
     # This route action does not exist


### PR DESCRIPTION
For [PLATFORM-425](https://frame-io.atlassian.net/browse/PLATFORM-425)

These look very similar to reusable response schemas defined via `Rolodex.Response`. So much so that a chunk of this diff is abstracted macro logic shared b/t Response and RequestBody into an (undocumented) helper module `Rolodex.ContentUtils`.

Key updates here:

- Define reusable request body schemas via `Rolodex.RequestBody` macros
- Updates to the processing pipeline to handle these new refs
- Refactor to ensure users can still pass in bare maps/keywords to define one-off request body or response schemas. In those cases, we'll use a default content-type value set in Config when serializing to OpenAPI