### PR TITLE
[PLATFORM-431] Support documenting multiple use action functions

### DIFF
--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -110,7 +110,9 @@ defmodule Rolodex.Config do
       end
   """
 
-  alias Rolodex.{PipelineConfig, Utils}
+  alias Rolodex.PipelineConfig
+
+  import Rolodex.Utils, only: [to_struct: 2, to_map_deep: 1]
 
   @enforce_keys [
     :description,
@@ -180,7 +182,7 @@ defmodule Rolodex.Config do
     |> Map.new()
     |> set_pipelines_config(module)
     |> set_auth_config(module)
-    |> Utils.to_struct(__MODULE__)
+    |> to_struct(__MODULE__)
   end
 
   defp set_pipelines_config(opts, module) do
@@ -192,7 +194,7 @@ defmodule Rolodex.Config do
   end
 
   def set_auth_config(opts, module),
-    do: Map.put(opts, :auth, module.auth_spec() |> Utils.to_map_deep())
+    do: Map.put(opts, :auth, module.auth_spec() |> to_map_deep())
 end
 
 defmodule Rolodex.PipelineConfig do
@@ -217,7 +219,7 @@ defmodule Rolodex.PipelineConfig do
       }
   """
 
-  alias Rolodex.Utils
+  import Rolodex.Utils, only: [to_struct: 2, to_map_deep: 1]
 
   defstruct auth: [],
             body: %{},
@@ -238,7 +240,7 @@ defmodule Rolodex.PipelineConfig do
   @spec new(list() | map()) :: t()
   def new(params \\ []) do
     params
-    |> Map.new(fn {k, v} -> {k, Utils.to_map_deep(v)} end)
-    |> Utils.to_struct(__MODULE__)
+    |> Map.new(fn {k, v} -> {k, to_map_deep(v)} end)
+    |> to_struct(__MODULE__)
   end
 end

--- a/lib/rolodex/processors/swagger.ex
+++ b/lib/rolodex/processors/swagger.ex
@@ -11,7 +11,9 @@ defmodule Rolodex.Processors.Swagger do
     :type
   ]
 
-  alias Rolodex.{Config, Field, Route, Utils}
+  alias Rolodex.{Config, Field, Route}
+
+  import Rolodex.Utils, only: [camelize_map: 1]
 
   @impl Rolodex.Processor
   def process(config, routes, serialized_refs) do
@@ -141,7 +143,7 @@ defmodule Rolodex.Processors.Swagger do
       requestBodies: process_content_body_refs(request_bodies, :__request_body__),
       responses: process_content_body_refs(responses, :__response__),
       schemas: process_schema_refs(schemas),
-      securitySchemes: Utils.camelize_map(auth)
+      securitySchemes: camelize_map(auth)
     }
   end
 

--- a/lib/rolodex/utils.ex
+++ b/lib/rolodex/utils.ex
@@ -1,6 +1,13 @@
 defmodule Rolodex.Utils do
+  @moduledoc false
+
+  # Pipeline friendly dynamic struct creator
   def to_struct(data, module), do: struct(module, data)
 
+  # Pipeline friendly helper to generate {:ok, result} tuples
+  def ok(data), do: {:ok, data}
+
+  # Recursively convert a keyword list into a map
   def to_map_deep(data, level \\ 0)
   def to_map_deep([], 0), do: %{}
 
@@ -13,6 +20,7 @@ defmodule Rolodex.Utils do
 
   def to_map_deep(data, _), do: data
 
+  # Recursively convert all keys in a map from snake_case to camelCase
   def camelize_map(data) when not is_map(data), do: data
 
   def camelize_map(data) do

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -184,6 +184,51 @@ defmodule Rolodex.RouteTest do
              }
     end
 
+    test "It uses the Phoenix route path to pull out docs for a multi-headed controller action",
+         %{
+           config: config
+         } do
+      result =
+        %Router.Route{
+          plug: TestController,
+          opts: :multi,
+          path: "/api/nested/:nested_id/multi",
+          verb: :get
+        }
+        |> Route.new(config)
+
+      assert result == %Route{
+               auth: %{JWTAuth: []},
+               desc: "It's an action used for multiple routes",
+               path_params: %{
+                 nested_id: %{type: :uuid, required: true}
+               },
+               responses: %{
+                 200 => %{type: :ref, ref: UserResponse},
+                 404 => %{type: :ref, ref: ErrorResponse}
+               },
+               path: "/api/nested/:nested_id/multi",
+               verb: :get,
+               pipe_through: nil
+             }
+    end
+
+    test "It returns nil if no path matches the Phoenix route path for a multi-headed controller action",
+         %{
+           config: config
+         } do
+      result =
+        %Router.Route{
+          plug: TestController,
+          opts: :multi,
+          path: "/multi/:nested_id/multi/non-existent",
+          verb: :get
+        }
+        |> Route.new(config)
+
+      assert result == nil
+    end
+
     test "Controller action params will win if in conflict with pipeline params", %{
       config: config
     } do

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -349,6 +349,37 @@ defmodule RolodexTest do
                      },
                      "summary" => ""
                    }
+                 },
+                 "/api/multi" => %{
+                   "get" => %{
+                     "parameters" => [],
+                     "requestBody" => %{},
+                     "responses" => %{
+                       "200" => %{"$ref" => "#/components/responses/UserResponse"},
+                       "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
+                     },
+                     "security" => [%{"JWTAuth" => []}],
+                     "summary" => "It's an action used for multiple routes"
+                   }
+                 },
+                 "/api/nested/{nested_id}/multi" => %{
+                   "get" => %{
+                     "parameters" => [
+                       %{
+                         "in" => "path",
+                         "name" => "nested_id",
+                         "required" => true,
+                         "schema" => %{"format" => "uuid", "type" => "string"}
+                       }
+                     ],
+                     "requestBody" => %{},
+                     "responses" => %{
+                       "200" => %{"$ref" => "#/components/responses/UserResponse"},
+                       "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
+                     },
+                     "security" => [%{"JWTAuth" => []}],
+                     "summary" => "It's an action used for multiple routes"
+                   }
                  }
                }
              }
@@ -415,7 +446,7 @@ defmodule RolodexTest do
         |> Rolodex.generate_routes()
         |> length()
 
-      assert num_routes == 3
+      assert num_routes == 5
     end
   end
 

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -39,6 +39,29 @@ defmodule Rolodex.Mocks.TestController do
   def index(_, _), do: nil
 
   @doc [
+    multi: true,
+    "/api/multi": [
+      auth: :JWTAuth,
+      responses: %{
+        200 => UserResponse,
+        404 => ErrorResponse
+      }
+    ],
+    "/api/nested/:nested_id/multi": [
+      auth: :JWTAuth,
+      path_params: [
+        nested_id: [type: :uuid, required: true]
+      ],
+      responses: %{
+        200 => UserResponse,
+        404 => ErrorResponse
+      }
+    ]
+  ]
+  @doc "It's an action used for multiple routes"
+  def multi(_, _), do: nil
+
+  @doc [
     auth: :JWTAuth,
     headers: %{"X-Request-Id" => :string}
   ]

--- a/test/support/mocks/routers.ex
+++ b/test/support/mocks/routers.ex
@@ -7,7 +7,11 @@ defmodule Rolodex.Mocks.TestRouter do
     put("/demo/:id", TestController, :with_bare_maps)
     delete("/demo/:id", TestController, :undocumented)
 
+    # Multi-headed action function
+    get("/multi", TestController, :multi)
+    get("/nested/:nested_id/multi", TestController, :multi)
+
     # This route action does not exist
-    put("/demo/:id", TestController, :missing_action)
+    put("/demo/missing/:id", TestController, :missing_action)
   end
 end


### PR DESCRIPTION
A Phoenix controller action can be used multiple times for different
router paths. The docs for each path may differ significantly, so we
want a way to support multiple doc definitions per action function.

Our approach: a top level `multi: true` flag on the @doc annotation.
Every other top-level key corresponds to a router path. The value for
each path key is the docs for that router path.