### PR TITLE
[PLATFORM-543] Some dogfooding fixes

### DIFF
--- a/test/rolodex/processors/swagger_test.exs
+++ b/test/rolodex/processors/swagger_test.exs
@@ -124,7 +124,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                      "content" => %{
                        "application/json" => %{
                          "examples" => %{
-                           "request" => %{"id" => "1"}
+                           "request" => %{"value" => %{"id" => "1"}}
                          },
                          "schema" => %{
                            "$ref" => "#/components/schemas/User"
@@ -138,7 +138,9 @@ defmodule Rolodex.Processors.SwaggerTest do
                    "UserResponse" => %{
                      "content" => %{
                        "application/json" => %{
-                         "examples" => %{"response" => %{"id" => "1"}},
+                         "examples" => %{
+                           "response" => %{"value" => %{"id" => "1"}}
+                         },
                          "schema" => %{
                            "$ref" => "#/components/schemas/User"
                          }
@@ -364,7 +366,6 @@ defmodule Rolodex.Processors.SwaggerTest do
                  get: %{
                    summary: "GET /foo",
                    security: [],
-                   requestBody: %{},
                    parameters: [],
                    responses: %{
                      200 => %{
@@ -377,7 +378,6 @@ defmodule Rolodex.Processors.SwaggerTest do
                  get: %{
                    summary: "GET /foo/{id}",
                    security: [],
-                   requestBody: %{},
                    parameters: [],
                    responses: %{
                      200 => %{
@@ -388,7 +388,6 @@ defmodule Rolodex.Processors.SwaggerTest do
                  post: %{
                    summary: "POST /foo/{id}",
                    security: [],
-                   requestBody: %{},
                    parameters: [],
                    responses: %{
                      200 => %{
@@ -420,7 +419,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                  "UserRequestBody" => %{
                    content: %{
                      "application/json" => %{
-                       examples: %{request: %{id: "1"}},
+                       examples: %{request: %{value: %{id: "1"}}},
                        schema: %{
                          "$ref" => "#/components/schemas/User"
                        }
@@ -433,7 +432,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                  "UserResponse" => %{
                    content: %{
                      "application/json" => %{
-                       examples: %{response: %{id: "1"}},
+                       examples: %{response: %{value: %{id: "1"}}},
                        schema: %{
                          "$ref" => "#/components/schemas/User"
                        }

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -78,7 +78,7 @@ defmodule RolodexTest do
                      "content" => %{
                        "application/json" => %{
                          "examples" => %{
-                           "request" => %{"id" => "1"}
+                           "request" => %{"value" => %{"id" => "1"}}
                          },
                          "schema" => %{
                            "$ref" => "#/components/schemas/User"
@@ -107,7 +107,9 @@ defmodule RolodexTest do
                    "PaginatedUsersResponse" => %{
                      "content" => %{
                        "application/json" => %{
-                         "examples" => %{"response" => [%{"id" => "1"}]},
+                         "examples" => %{
+                           "response" => %{"value" => [%{"id" => "1"}]}
+                         },
                          "schema" => %{
                            "properties" => %{
                              "page" => %{"type" => "integer"},
@@ -128,7 +130,9 @@ defmodule RolodexTest do
                    "UserResponse" => %{
                      "content" => %{
                        "application/json" => %{
-                         "examples" => %{"response" => %{"id" => "1"}},
+                         "examples" => %{
+                           "response" => %{"value" => %{"id" => "1"}}
+                         },
                          "schema" => %{
                            "$ref" => "#/components/schemas/User"
                          }
@@ -308,7 +312,6 @@ defmodule RolodexTest do
                          }
                        }
                      ],
-                     "requestBody" => %{},
                      "responses" => %{},
                      "summary" => ""
                    },
@@ -353,7 +356,6 @@ defmodule RolodexTest do
                  "/api/multi" => %{
                    "get" => %{
                      "parameters" => [],
-                     "requestBody" => %{},
                      "responses" => %{
                        "200" => %{"$ref" => "#/components/responses/UserResponse"},
                        "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
@@ -372,7 +374,6 @@ defmodule RolodexTest do
                          "schema" => %{"format" => "uuid", "type" => "string"}
                        }
                      ],
-                     "requestBody" => %{},
                      "responses" => %{
                        "200" => %{"$ref" => "#/components/responses/UserResponse"},
                        "404" => %{"$ref" => "#/components/responses/ErrorResponse"}


### PR DESCRIPTION
- OpenAPI 3.0 requires that we _omit_ the `requestBody` field for a
  route doc when there is no request body required
- Properly key response examples