### PR TITLE
Removes Flow

### DIFF
--- a/lib/rolodex.ex
+++ b/lib/rolodex.ex
@@ -295,10 +295,8 @@ defmodule Rolodex do
   @spec generate_routes(Rolodex.Config.t()) :: [Rolodex.Route.t()]
   def generate_routes(%Config{router: router} = config) do
     router.__routes__()
-    |> Flow.from_enumerable()
-    |> Flow.map(&Route.new(&1, config))
-    |> Flow.reject(&(&1 == nil || Route.matches_filter?(&1, config)))
-    |> Enum.to_list()
+    |> Enum.map(&Route.new(&1, config))
+    |> Enum.reject(&(&1 == nil || Route.matches_filter?(&1, config)))
   end
 
   @doc """
@@ -309,13 +307,11 @@ defmodule Rolodex do
   """
   @spec generate_refs([Rolodex.Route.t()]) :: map()
   def generate_refs(routes) do
-    routes
-    |> Flow.from_enumerable()
-    |> Flow.reduce(
-      fn -> %{schemas: %{}, responses: %{}, request_bodies: %{}} end,
+    Enum.reduce(
+      routes,
+      %{schemas: %{}, responses: %{}, request_bodies: %{}},
       &refs_for_route/2
     )
-    |> Map.new()
   end
 
   defp refs_for_route(route, all_refs) do

--- a/lib/rolodex/processors/swagger.ex
+++ b/lib/rolodex/processors/swagger.ex
@@ -44,12 +44,10 @@ defmodule Rolodex.Processors.Swagger do
   @impl Rolodex.Processor
   def process_routes(routes, config) do
     routes
-    |> Flow.from_enumerable()
-    |> Flow.group_by(&path_with_params/1)
-    |> Flow.map(fn {path, routes} ->
+    |> Enum.group_by(&path_with_params/1)
+    |> Map.new(fn {path, routes} ->
       {path, process_routes_for_path(routes, config)}
     end)
-    |> Map.new()
   end
 
   # Transform Phoenix-style path params to Swagger-style: /foo/:bar -> /foo/{bar}
@@ -152,14 +150,11 @@ defmodule Rolodex.Processors.Swagger do
   end
 
   defp process_content_body_refs(refs, ref_type) do
-    refs
-    |> Flow.from_enumerable()
-    |> Flow.map(fn {mod, ref} ->
+    Map.new(refs, fn {mod, ref} ->
       name = apply(mod, ref_type, [:name])
       content = process_content_body_ref(ref)
       {name, content}
     end)
-    |> Map.new()
   end
 
   defp process_content_body_ref(%{desc: desc, content: content}) do
@@ -184,12 +179,9 @@ defmodule Rolodex.Processors.Swagger do
     do: Map.new(examples, fn {name, example} -> {name, %{value: example}} end)
 
   defp process_schema_refs(schemas) do
-    schemas
-    |> Flow.from_enumerable()
-    |> Flow.map(fn {mod, schema} ->
+    Map.new(schemas, fn {mod, schema} ->
       {mod.__schema__(:name), process_schema_field(schema)}
     end)
-    |> Map.new()
   end
 
   defp process_schema_field(%{type: :ref, ref: ref}) when ref != nil do

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,6 @@ defmodule Rolodex.MixProject do
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       {:jason, "~> 1.1"},
-      {:flow, "~> 0.14.3"},
       {:phoenix, "~> 1.4.0"},
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev}


### PR DESCRIPTION
Reworks https://github.com/Frameio/rolodex/pull/31
Closes https://github.com/Frameio/rolodex/issues/27

At the moment, even with a large Phoenix router, we don't need Flow
to reduce load when generating docs. In fact, the overhead introduced
by Flow (spinning up GenStage processes) means that without Flow docs
generate faster.