### PR TITLE
[PLATFORM-543] Refactor Rolodex.Schema.field/3 macro

### DIFF
--- a/test/rolodex/processors/swagger_test.exs
+++ b/test/rolodex/processors/swagger_test.exs
@@ -197,6 +197,15 @@ defmodule Rolodex.Processors.SwaggerTest do
                        },
                        "parent" => %{
                          "$ref" => "#/components/schemas/Parent"
+                       },
+                       "private" => %{
+                         "type" => "boolean"
+                       },
+                       "archived" => %{
+                         "type" => "boolean"
+                       },
+                       "active" => %{
+                         "type" => "boolean"
                        }
                      }
                    }
@@ -489,7 +498,10 @@ defmodule Rolodex.Processors.SwaggerTest do
                      },
                      parent: %{
                        "$ref" => "#/components/schemas/Parent"
-                     }
+                     },
+                     private: %{type: :boolean},
+                     archived: %{type: :boolean},
+                     active: %{type: :boolean}
                    }
                  }
                },

--- a/test/rolodex/schema_test.exs
+++ b/test/rolodex/schema_test.exs
@@ -17,52 +17,31 @@ defmodule Rolodex.SchemaTest do
       assert User.__schema__(:name) == "User"
       assert User.__schema__(:desc) == "A user record"
 
-      assert User.__schema__(:fields) == [
-               :id,
-               :email,
-               :comment,
-               :parent,
-               :comments,
-               :comments_of_many_types,
-               :multi
-             ]
-    end
-  end
-
-  describe "#field/3 macro" do
-    test "It generates getters" do
-      assert User.__field__(:id) ==
-               {:id, %{type: :uuid, desc: "The id of the user", required: true}}
-
-      assert User.__field__(:email) ==
-               {:email, %{type: :string, desc: "The email of the user", required: true}}
-
-      assert User.__field__(:comment) == {:comment, %{type: :ref, ref: Comment}}
-      assert User.__field__(:parent) == {:parent, %{type: :ref, ref: Parent}}
-
-      assert User.__field__(:comments) ==
-               {:comments, %{type: :list, of: [%{type: :ref, ref: Comment}]}}
-
-      assert User.__field__(:comments_of_many_types) ==
-               {:comments_of_many_types,
-                %{
-                  desc: "List of text or comment",
-                  type: :list,
-                  of: [
-                    %{type: :string},
-                    %{type: :ref, ref: Comment}
-                  ]
-                }}
-
-      assert User.__field__(:multi) ==
-               {:multi,
-                %{
-                  type: :one_of,
-                  of: [
-                    %{type: :string},
-                    %{type: :ref, ref: NotFound}
-                  ]
-                }}
+      assert User.__schema__(:fields) == %{
+               id: %{type: :uuid, desc: "The id of the user", required: true},
+               email: %{type: :string, desc: "The email of the user", required: true},
+               comment: %{type: :ref, ref: Comment},
+               parent: %{type: :ref, ref: Parent},
+               comments: %{type: :list, of: [%{type: :ref, ref: Comment}]},
+               comments_of_many_types: %{
+                 desc: "List of text or comment",
+                 type: :list,
+                 of: [
+                   %{type: :string},
+                   %{type: :ref, ref: Comment}
+                 ]
+               },
+               multi: %{
+                 type: :one_of,
+                 of: [
+                   %{type: :string},
+                   %{type: :ref, ref: NotFound}
+                 ]
+               },
+               private: %{type: :boolean},
+               archived: %{type: :boolean},
+               active: %{type: :boolean}
+             }
     end
   end
 
@@ -94,7 +73,10 @@ defmodule Rolodex.SchemaTest do
                      %{type: :string},
                      %{type: :ref, ref: NotFound}
                    ]
-                 }
+                 },
+                 private: %{type: :boolean},
+                 archived: %{type: :boolean},
+                 active: %{type: :boolean}
                }
              }
     end

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -216,6 +216,15 @@ defmodule RolodexTest do
                        },
                        "parent" => %{
                          "$ref" => "#/components/schemas/Parent"
+                       },
+                       "private" => %{
+                         "type" => "boolean"
+                       },
+                       "archived" => %{
+                         "type" => "boolean"
+                       },
+                       "active" => %{
+                         "type" => "boolean"
                        }
                      }
                    }

--- a/test/support/mocks/schemas.ex
+++ b/test/support/mocks/schemas.ex
@@ -1,6 +1,12 @@
 defmodule Rolodex.Mocks.User do
   use Rolodex.Schema
 
+  @configs [
+    private: :boolean,
+    archived: :boolean,
+    active: :boolean
+  ]
+
   schema "User", desc: "A user record" do
     field(:id, :uuid, desc: "The id of the user", required: true)
     field(:email, :string, desc: "The email of the user", required: true)
@@ -22,6 +28,9 @@ defmodule Rolodex.Mocks.User do
 
     # A field with multiple possible types
     field(:multi, :one_of, of: [:string, Rolodex.Mocks.NotFound])
+
+    # Can use a for comprehension to define many fields
+    for {name, type} <- @configs, do: field(name, type)
   end
 end
 


### PR DESCRIPTION
Rather than define a bunch of `__field__/1` functions on the caller
module as the `field/3` macro is invoked, we only collect field
definition metadata in an accumulator attribute. Later, we serialize
the field definitions together into a formatted map on demand via
`__schema__(:fields)`.

This change will allow users to define fields on their schemas in
for comprehensions or maps, without any compiler warnings about
unmatchable function heads.