### PR TITLE
[PLATFORM-398] add support for operationId

### DIFF
--- a/lib/rolodex/processors/swagger.ex
+++ b/lib/rolodex/processors/swagger.ex
@@ -68,6 +68,7 @@ defmodule Rolodex.Processors.Swagger do
       # whereas `description` is meant for multi-line markdown explainers.
       #
       # TODO(bceskavich): we could support both?
+      operationId: route.id,
       summary: route.desc,
       tags: route.tags,
       parameters: process_params(route),

--- a/lib/rolodex/route.ex
+++ b/lib/rolodex/route.ex
@@ -18,6 +18,14 @@ defmodule Rolodex.Route do
       @doc "My route description"
       def route(_, _), do: nil
 
+  * **`id`** (Default: `""`)
+
+  Route identifier. Used as an optional unique identifier for the route.
+
+      @doc [
+        id: "foobar"
+      ]
+
   * **`body`** *(Default: `%{}`)
 
   Request body parameters. Valid inputs: `Rolodex.RequestBody`, or a map or
@@ -357,6 +365,7 @@ defmodule Rolodex.Route do
   defstruct [
     :path,
     :verb,
+    id: "",
     auth: %{},
     body: %{},
     desc: "",
@@ -372,6 +381,7 @@ defmodule Rolodex.Route do
   @phoenix_route_params [:path, :pipe_through, :verb]
 
   @type t :: %__MODULE__{
+          id: binary(),
           auth: map(),
           body: map(),
           desc: binary(),

--- a/test/rolodex/processors/swagger_test.exs
+++ b/test/rolodex/processors/swagger_test.exs
@@ -74,6 +74,7 @@ defmodule Rolodex.Processors.SwaggerTest do
 
       routes = [
         %Route{
+          id: "foo",
           auth: %{
             JWTAuth: [],
             OAuth: ["user.read"]
@@ -101,6 +102,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                "paths" => %{
                  "/foo" => %{
                    "get" => %{
+                     "operationId" => "foo",
                      "summary" => "It does a thing",
                      "tags" => [],
                      "security" => [
@@ -258,6 +260,7 @@ defmodule Rolodex.Processors.SwaggerTest do
     test "It takes a list of routes and refs and returns a formatted map" do
       routes = [
         %Route{
+          id: "foo",
           desc: "It does a thing",
           auth: %{JWTAuth: []},
           headers: %{
@@ -292,6 +295,7 @@ defmodule Rolodex.Processors.SwaggerTest do
       assert processed == %{
                "/foo" => %{
                  get: %{
+                   operationId: "foo",
                    summary: "It does a thing",
                    tags: [],
                    security: [%{JWTAuth: []}],
@@ -353,18 +357,21 @@ defmodule Rolodex.Processors.SwaggerTest do
     test "It collects routes by path" do
       routes = [
         %Route{
+          id: "foo",
           path: "/foo",
           verb: :get,
           desc: "GET /foo",
           responses: %{200 => %{type: :ref, ref: UserResponse}}
         },
         %Route{
+          id: "foobar",
           path: "/foo/:id",
           verb: :get,
           desc: "GET /foo/{id}",
           responses: %{200 => %{type: :ref, ref: UserResponse}}
         },
         %Route{
+          id: "foobuzz",
           path: "/foo/:id",
           verb: :post,
           desc: "POST /foo/{id}",
@@ -375,6 +382,7 @@ defmodule Rolodex.Processors.SwaggerTest do
       assert Swagger.process_routes(routes, Config.new(BasicConfig)) == %{
                "/foo" => %{
                  get: %{
+                   operationId: "foo",
                    summary: "GET /foo",
                    security: [],
                    parameters: [],
@@ -388,6 +396,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                },
                "/foo/{id}" => %{
                  get: %{
+                   operationId: "foobar",
                    summary: "GET /foo/{id}",
                    security: [],
                    parameters: [],
@@ -399,6 +408,7 @@ defmodule Rolodex.Processors.SwaggerTest do
                    }
                  },
                  post: %{
+                   operationId: "foobuzz",
                    summary: "POST /foo/{id}",
                    security: [],
                    parameters: [],

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -257,6 +257,7 @@ defmodule RolodexTest do
                "paths" => %{
                  "/api/demo" => %{
                    "get" => %{
+                     "operationId" => "",
                      "security" => [
                        %{"JWTAuth" => []},
                        %{"OAuth" => ["user.read"]},
@@ -312,6 +313,7 @@ defmodule RolodexTest do
                  },
                  "/api/demo/{id}" => %{
                    "post" => %{
+                     "operationId" => "",
                      "security" => [%{"JWTAuth" => []}],
                      "parameters" => [
                        %{
@@ -327,6 +329,7 @@ defmodule RolodexTest do
                      "tags" => []
                    },
                    "put" => %{
+                     "operationId" => "",
                      "security" => [],
                      "parameters" => [],
                      "requestBody" => %{
@@ -367,6 +370,7 @@ defmodule RolodexTest do
                  },
                  "/api/multi" => %{
                    "get" => %{
+                     "operationId" => "",
                      "parameters" => [],
                      "responses" => %{
                        "200" => %{"$ref" => "#/components/responses/UserResponse"},
@@ -379,6 +383,7 @@ defmodule RolodexTest do
                  },
                  "/api/nested/{nested_id}/multi" => %{
                    "get" => %{
+                     "operationId" => "",
                      "parameters" => [
                        %{
                          "in" => "path",


### PR DESCRIPTION
Adds support for Swagger [`operationId`](https://swagger.io/docs/specification/paths-and-operations/)