### PR TITLE
Add support for response headers, reusable headers

### DIFF
--- a/lib/rolodex/content_utils.ex
+++ b/lib/rolodex/content_utils.ex
@@ -8,8 +8,10 @@ defmodule Rolodex.ContentUtils do
       Module.register_attribute(__MODULE__, :content_types, accumulate: true)
       Module.register_attribute(__MODULE__, :current_content_type, accumulate: false)
       Module.register_attribute(__MODULE__, :body_description, accumulate: false)
+      Module.register_attribute(__MODULE__, :headers, accumulate: false)
 
       @body_description nil
+      @headers nil
 
       unquote(block)
 
@@ -17,6 +19,7 @@ defmodule Rolodex.ContentUtils do
 
       def unquote(type)(:name), do: unquote(name)
       def unquote(type)(:desc), do: @body_description
+      def unquote(type)(:headers), do: @headers
       def unquote(type)(:content_types), do: @content_types |> Enum.reverse()
     end
   end
@@ -24,6 +27,18 @@ defmodule Rolodex.ContentUtils do
   def set_desc(str) do
     quote do
       @body_description unquote(str)
+    end
+  end
+
+  def set_headers({:__aliases__, _, _} = mod) do
+    quote do
+      @headers Field.new(unquote(mod))
+    end
+  end
+
+  def set_headers(headers) do
+    quote do
+      @headers unquote(headers) |> Map.new(fn {header, opts} -> {header, Field.new(opts)} end)
     end
   end
 
@@ -88,6 +103,7 @@ defmodule Rolodex.ContentUtils do
   def to_map(fun) do
     %{
       desc: fun.(:desc),
+      headers: fun.(:headers),
       content: serialize_content(fun)
     }
   end
@@ -112,13 +128,26 @@ defmodule Rolodex.ContentUtils do
   def get_refs(fun) do
     fun
     |> to_map()
-    |> Map.get(:content)
-    |> Enum.reduce(MapSet.new(), fn {_, %{schema: schema}}, acc ->
+    |> Map.take([:headers, :content])
+    |> collect_refs(MapSet.new())
+    |> Enum.to_list()
+  end
+
+  def collect_refs(data, refs) do
+    refs
+    |> set_headers_ref(data)
+    |> set_content_refs(data)
+  end
+
+  defp set_headers_ref(refs, %{headers: %{type: :ref, ref: ref}}), do: MapSet.put(refs, ref)
+  defp set_headers_ref(refs, _), do: refs
+
+  defp set_content_refs(refs, %{content: content}) do
+    Enum.reduce(content, refs, fn {_, %{schema: schema}}, acc ->
       schema
       |> Field.get_refs()
       |> MapSet.new()
       |> MapSet.union(acc)
     end)
-    |> Enum.to_list()
   end
 end

--- a/lib/rolodex/content_utils.ex
+++ b/lib/rolodex/content_utils.ex
@@ -90,6 +90,16 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  def set_field(attr, identifier, type, opts) do
+    quote do
+      Module.put_attribute(
+        __MODULE__,
+        unquote(attr),
+        {unquote(identifier), [type: unquote(type)] ++ unquote(opts)}
+      )
+    end
+  end
+
   def is_module_of_type?(mod, type) when is_atom(mod) do
     try do
       mod.__info__(:functions) |> Keyword.has_key?(type)

--- a/lib/rolodex/field.ex
+++ b/lib/rolodex/field.ex
@@ -9,9 +9,10 @@ defmodule Rolodex.Field do
   Response, or Schema.
   """
 
-  alias Rolodex.{RequestBody, Response, Schema}
+  alias Rolodex.{Headers, RequestBody, Response, Schema}
 
-  @type ref_type :: :request_body | :response | :schema
+  @type ref_type :: :headers | :request_body | :response | :schema
+  @ref_types [:headers, :request_body, :response, :schema]
 
   @doc """
   Parses parameter data into maps with a standardized shape.
@@ -163,11 +164,8 @@ defmodule Rolodex.Field do
 
   defp create_field(%{type: type} = metadata) do
     cond do
-      get_ref_type(type) in [:request_body, :response, :schema] ->
-        %{type: :ref, ref: type}
-
-      true ->
-        metadata
+      get_ref_type(type) in @ref_types -> %{type: :ref, ref: type}
+      true -> metadata
     end
   end
 
@@ -257,7 +255,8 @@ defmodule Rolodex.Field do
   end
 
   @doc """
-  Takes a module and determines if it is a Response, a Schema, or neither
+  Takes a module and determines if it is a known shared module ref type: Headers,
+  RequestBody, Response, or Schema.
   """
   @spec get_ref_type(module()) :: ref_type() | :error
   def get_ref_type(mod) do
@@ -265,6 +264,7 @@ defmodule Rolodex.Field do
       RequestBody.is_request_body_module?(mod) -> :request_body
       Response.is_response_module?(mod) -> :response
       Schema.is_schema_module?(mod) -> :schema
+      Headers.is_headers_module?(mod) -> :headers
       true -> :error
     end
   end

--- a/lib/rolodex/headers.ex
+++ b/lib/rolodex/headers.ex
@@ -1,0 +1,127 @@
+defmodule Rolodex.Headers do
+  @moduledoc """
+  Exposes functions and macros for defining reusable headers in route doc
+  annotations or responses.
+
+  It exposes the following macros, which when used together will set up the headers:
+
+  - `headers/2` - for declaring the headers
+  - `header/3` - for declaring a single header for the set
+
+  It also exposes the following functions:
+
+  - `is_headers_module?/1` - determines if the provided item is a module that has
+  defined a reusable headers set
+  - `to_map/1` - serializes the headers module into a map
+  """
+
+  alias Rolodex.Field
+
+  defmacro __using__(_) do
+    quote do
+      import Rolodex.Headers, only: :macros
+    end
+  end
+
+  @doc """
+  Opens up the headers definition for the current module. Will name the headers
+  set and generate a list of header fields based on the macro calls within.
+
+  **Accepts**
+  - `name` - the headers name
+  - `block` - headers shape definition
+
+  ## Example
+
+      defmodule SimpleHeaders do
+        use Rolodex.Headers
+
+        headers "SimpleHeaders" do
+          header "X-Rate-Limited", :boolean
+          header "X-Per-Page", :integer, desc: "Number of items in the response"
+        end
+      end
+  """
+  defmacro headers(name, do: block) do
+    quote do
+      Module.register_attribute(__MODULE__, :headers, accumulate: true)
+
+      unquote(block)
+
+      def __headers__(:name), do: unquote(name)
+      def __headers__(:headers), do: Map.new(@headers, fn {id, opts} -> {id, Field.new(opts)} end)
+    end
+  end
+
+  @doc """
+  Sets a header field.
+
+  **Accepts**
+
+  - `identifier` - the header name
+  - `type` - the header field type
+  - `opts` (optional) - additional metadata. See `Field.new/1` for a list of
+  valid options.
+  """
+  defmacro header(identifier, type, opts \\ []) do
+    quote do
+      @headers {unquote(identifier), [type: unquote(type)] ++ unquote(opts)}
+    end
+  end
+
+  @doc """
+  Determines if an arbitrary item is a module that has defined a reusable headers
+  set via `Rolodex.Headers` macros
+
+  ## Example
+
+      defmodule SimpleHeaders do
+      ...>   use Rolodex.Headers
+      ...>   headers "SimpleHeaders" do
+      ...>     header "X-Rate-Limited", :boolean
+      ...>   end
+      ...> end
+      iex>
+      # Validating a headers module
+      Rolodex.Headers.is_headers_module?(SimpleHeaders)
+      true
+      iex> # Validating some other module
+      iex> Rolodex.Headers.is_headers_module?(OtherModule)
+      false
+  """
+  @spec is_headers_module?(any()) :: boolean()
+  def is_headers_module?(item)
+
+  def is_headers_module?(module) when is_atom(module) do
+    try do
+      module.__info__(:functions) |> Keyword.has_key?(:__headers__)
+    rescue
+      _ -> false
+    end
+  end
+
+  def is_headers_module?(_), do: false
+
+  @doc """
+  Serializes the `Rolodex.Headers` metadata into a formatted map
+
+  ## Example
+
+      iex> defmodule SimpleHeaders do
+      ...>   use Rolodex.Headers
+      ...>
+      ...>   headers "SimpleHeaders" do
+      ...>     header "X-Rate-Limited", :boolean
+      ...>     header "X-Per-Page", :integer, desc: "Number of items in the response"
+      ...>   end
+      ...> end
+      iex>
+      iex> Rolodex.Headers.to_map(SimpleHeaders)
+      %{
+        "X-Per-Page" => %{desc: "Number of items in the response", type: :integer},
+        "X-Rate-Limited" => %{type: :boolean}
+      }
+  """
+  @spec to_map(module()) :: map()
+  def to_map(mod), do: mod.__headers__(:headers)
+end

--- a/lib/rolodex/headers.ex
+++ b/lib/rolodex/headers.ex
@@ -15,7 +15,7 @@ defmodule Rolodex.Headers do
   - `to_map/1` - serializes the headers module into a map
   """
 
-  alias Rolodex.Field
+  alias Rolodex.{ContentUtils, Field}
 
   defmacro __using__(_) do
     quote do
@@ -37,8 +37,8 @@ defmodule Rolodex.Headers do
         use Rolodex.Headers
 
         headers "SimpleHeaders" do
-          header "X-Rate-Limited", :boolean
-          header "X-Per-Page", :integer, desc: "Number of items in the response"
+          field "X-Rate-Limited", :boolean
+          field "X-Per-Page", :integer, desc: "Number of items in the response"
         end
       end
   """
@@ -63,10 +63,8 @@ defmodule Rolodex.Headers do
   - `opts` (optional) - additional metadata. See `Field.new/1` for a list of
   valid options.
   """
-  defmacro header(identifier, type, opts \\ []) do
-    quote do
-      @headers {unquote(identifier), [type: unquote(type)] ++ unquote(opts)}
-    end
+  defmacro field(identifier, type, opts \\ []) do
+    ContentUtils.set_field(:headers, identifier, type, opts)
   end
 
   @doc """
@@ -78,7 +76,7 @@ defmodule Rolodex.Headers do
       defmodule SimpleHeaders do
       ...>   use Rolodex.Headers
       ...>   headers "SimpleHeaders" do
-      ...>     header "X-Rate-Limited", :boolean
+      ...>     field "X-Rate-Limited", :boolean
       ...>   end
       ...> end
       iex>
@@ -111,8 +109,8 @@ defmodule Rolodex.Headers do
       ...>   use Rolodex.Headers
       ...>
       ...>   headers "SimpleHeaders" do
-      ...>     header "X-Rate-Limited", :boolean
-      ...>     header "X-Per-Page", :integer, desc: "Number of items in the response"
+      ...>     field "X-Rate-Limited", :boolean
+      ...>     field "X-Per-Page", :integer, desc: "Number of items in the response"
       ...>   end
       ...> end
       iex>

--- a/lib/rolodex/processors/swagger.ex
+++ b/lib/rolodex/processors/swagger.ex
@@ -11,7 +11,7 @@ defmodule Rolodex.Processors.Swagger do
     :type
   ]
 
-  alias Rolodex.{Config, Field, Route}
+  alias Rolodex.{Config, Field, Headers, Route}
 
   import Rolodex.Utils, only: [camelize_map: 1]
 
@@ -83,24 +83,24 @@ defmodule Rolodex.Processors.Swagger do
   end
 
   defp process_params(%Route{headers: headers, path_params: path, query_params: query}) do
-    [{:header, headers}, {:path, path}, {:query, query}]
+    [header: headers, path: path, query: query]
     |> Enum.flat_map(fn {location, params} ->
       Enum.map(params, &process_param(&1, location))
     end)
   end
 
   defp process_param({name, param}, location) do
-    result = %{
+    %{
       in: location,
       name: name,
       schema: process_schema_field(param)
     }
-
-    case Map.get(param, :required, false) do
-      true -> Map.put(result, :required, true)
-      false -> result
-    end
+    |> set_param_required(param)
+    |> set_param_description()
   end
+
+  defp set_param_required(param, %{required: true}), do: Map.put(param, :required, true)
+  defp set_param_required(param, _), do: param
 
   defp process_auth(%Route{auth: auth}), do: Enum.map(auth, &Map.new([&1]))
 
@@ -140,7 +140,11 @@ defmodule Rolodex.Processors.Swagger do
 
   @impl Rolodex.Processor
   def process_refs(
-        %{request_bodies: request_bodies, responses: responses, schemas: schemas},
+        %{
+          request_bodies: request_bodies,
+          responses: responses,
+          schemas: schemas
+        },
         %Config{auth: auth}
       ) do
     %{
@@ -159,7 +163,7 @@ defmodule Rolodex.Processors.Swagger do
     end)
   end
 
-  defp process_content_body_ref(%{desc: desc, content: content}) do
+  defp process_content_body_ref(%{desc: desc, content: content} = rest) do
     %{
       description: desc,
       content:
@@ -168,6 +172,7 @@ defmodule Rolodex.Processors.Swagger do
           {content_type, process_content_body_ref_data(content_val)}
         end)
     }
+    |> process_content_body_headers(rest)
   end
 
   defp process_content_body_ref_data(%{schema: schema, examples: examples}) do
@@ -179,6 +184,31 @@ defmodule Rolodex.Processors.Swagger do
 
   defp process_content_body_examples(examples),
     do: Map.new(examples, fn {name, example} -> {name, %{value: example}} end)
+
+  defp process_content_body_headers(content, %{headers: nil}), do: content
+
+  # OpenAPI 3 does not support using `$ref` syntax for reusable header components,
+  # so we need to serialize them out in full each time.
+  defp process_content_body_headers(content, %{headers: %{type: :ref, ref: ref}}) do
+    headers =
+      ref
+      |> Headers.to_map()
+      |> process_header_fields()
+
+    Map.put(content, :headers, headers)
+  end
+
+  defp process_content_body_headers(content, %{headers: headers}),
+    do: Map.put(content, :headers, process_header_fields(headers))
+
+  defp process_header_fields(fields) do
+    Map.new(fields, fn {header, value} -> {header, process_header_field(value)} end)
+  end
+
+  defp process_header_field(value) do
+    %{schema: process_schema_field(value)}
+    |> set_param_description()
+  end
 
   defp process_schema_refs(schemas) do
     Map.new(schemas, fn {mod, schema} ->
@@ -253,6 +283,16 @@ defmodule Rolodex.Processors.Swagger do
   end
 
   defp put_description(field, _), do: field
+
+  # When serializing parameters, descriptions should be placed in the top-level
+  # parameters map, not the nested schema definition
+  defp set_param_description(%{schema: %{description: description} = schema} = param) do
+    param
+    |> Map.put(:description, description)
+    |> Map.put(:schema, Map.delete(schema, :description))
+  end
+
+  defp set_param_description(param), do: param
 
   defp ref_path(mod) do
     case Field.get_ref_type(mod) do

--- a/lib/rolodex/request_body.ex
+++ b/lib/rolodex/request_body.ex
@@ -203,6 +203,7 @@ defmodule Rolodex.RequestBody do
       iex> Rolodex.RequestBody.to_map(MyRequestBody)
       %{
         desc: "A demo request body",
+        headers: nil,
         content: %{
           "application/json" => %{
             examples: %{

--- a/lib/rolodex/response.ex
+++ b/lib/rolodex/response.ex
@@ -70,6 +70,39 @@ defmodule Rolodex.Response do
   end
 
   @doc """
+  Sets headers to be included in the response. You can use a shared headers ref
+  defined via `Rolodex.Headers`, or just pass in a bare map or keyword list.
+
+  ## Examples
+
+      # Shared headers module
+      defmodule MyResponse do
+        use Rolodex.Response
+
+        response "MyResponse" do
+          headers MyResponseHeaders
+        end
+      end
+
+      # Headers defined in place
+      defmodule MyResponse do
+        use Rolodex.Response
+
+        response "MyResponse" do
+          headers %{
+            "X-Pagination" => %{
+              type: :integer,
+              description: "Pagination information"
+            }
+          }
+        end
+      end
+  """
+  defmacro headers(metadata) do
+    ContentUtils.set_headers(metadata)
+  end
+
+  @doc """
   Defines a response shape for the given content type key
 
   **Accepts**
@@ -124,7 +157,7 @@ defmodule Rolodex.Response do
   end
 
   @doc """
-  Sets a schema of a collection type.
+  Sets a collection of schemas for the current response content type.
 
   ## Examples
 
@@ -186,6 +219,8 @@ defmodule Rolodex.Response do
       ...>   response "MyResponse" do
       ...>     desc "A demo response"
       ...>
+      ...>     headers %{"X-Rate-Limited" => :boolean}
+      ...>
       ...>     content "application/json" do
       ...>       schema MySimpleSchema
       ...>       example :response, %{id: "123"}
@@ -202,6 +237,9 @@ defmodule Rolodex.Response do
       iex> Rolodex.Response.to_map(MyResponse)
       %{
         desc: "A demo response",
+        headers: %{
+          "X-Rate-Limited" => %{type: :boolean}
+        },
         content: %{
           "application/json" => %{
             examples: %{

--- a/lib/rolodex/schema.ex
+++ b/lib/rolodex/schema.ex
@@ -16,7 +16,7 @@ defmodule Rolodex.Schema do
   - `get_refs/1` - traverses a schema and searches for any nested schemas within
   """
 
-  alias Rolodex.Field
+  alias Rolodex.{ContentUtils, Field}
 
   defmacro __using__(_opts) do
     quote do
@@ -105,9 +105,7 @@ defmodule Rolodex.Schema do
       end
   """
   defmacro field(identifier, type, opts \\ []) do
-    quote do
-      @fields {unquote(identifier), [type: unquote(type)] ++ unquote(opts)}
-    end
+    ContentUtils.set_field(:fields, identifier, type, opts)
   end
 
   @doc """

--- a/test/rolodex/headers_test.exs
+++ b/test/rolodex/headers_test.exs
@@ -1,0 +1,43 @@
+defmodule Rolodex.HeadersTest do
+  use ExUnit.Case
+
+  alias Rolodex.Headers
+  alias Rolodex.Mocks.PaginationHeaders
+
+  doctest Headers
+
+  describe "#headers/2 macro" do
+    test "It generates headers metadata" do
+      assert PaginationHeaders.__headers__(:name) == "PaginationHeaders"
+
+      assert PaginationHeaders.__headers__(:headers) == %{
+               "total" => %{type: :integer, desc: "Total entries to be retrieved"},
+               "per-page" => %{
+                 type: :integer,
+                 desc: "Total entries per page of results",
+                 required: true
+               }
+             }
+    end
+  end
+
+  describe "#is_headers_module?/1" do
+    test "It returns the expected result" do
+      assert Headers.is_headers_module?(PaginationHeaders)
+      refute Headers.is_headers_module?(UnusedAlias)
+    end
+  end
+
+  describe "#to_map/1" do
+    test "It returns the serialized headers" do
+      assert Headers.to_map(PaginationHeaders) == %{
+               "total" => %{type: :integer, desc: "Total entries to be retrieved"},
+               "per-page" => %{
+                 type: :integer,
+                 desc: "Total entries per page of results",
+                 required: true
+               }
+             }
+    end
+  end
+end

--- a/test/rolodex/processors/swagger_test.exs
+++ b/test/rolodex/processors/swagger_test.exs
@@ -6,7 +6,8 @@ defmodule Rolodex.Processors.SwaggerTest do
     Response,
     Route,
     RequestBody,
-    Schema
+    Schema,
+    Headers
   }
 
   alias Rolodex.Processors.Swagger
@@ -15,7 +16,8 @@ defmodule Rolodex.Processors.SwaggerTest do
     ErrorResponse,
     User,
     UserRequestBody,
-    UserResponse
+    UserResponse,
+    RateLimitHeaders
   }
 
   defmodule(BasicConfig, do: use(Rolodex.Config))
@@ -69,6 +71,9 @@ defmodule Rolodex.Processors.SwaggerTest do
         },
         schemas: %{
           User => Schema.to_map(User)
+        },
+        headers: %{
+          RateLimitHeaders => Headers.to_map(RateLimitHeaders)
         }
       }
 
@@ -147,6 +152,12 @@ defmodule Rolodex.Processors.SwaggerTest do
                          "schema" => %{
                            "$ref" => "#/components/schemas/User"
                          }
+                       }
+                     },
+                     "headers" => %{
+                       "limited" => %{
+                         "description" => "Have you been rate limited",
+                         "schema" => %{"type" => "boolean"}
                        }
                      },
                      "description" => "A single user entity response"
@@ -312,10 +323,10 @@ defmodule Rolodex.Processors.SwaggerTest do
                      %{
                        in: :path,
                        name: :account_id,
+                       description: "The account id",
                        schema: %{
                          type: :string,
-                         format: :uuid,
-                         description: "The account id"
+                         format: :uuid
                        }
                      },
                      %{
@@ -435,6 +446,9 @@ defmodule Rolodex.Processors.SwaggerTest do
         },
         schemas: %{
           User => Schema.to_map(User)
+        },
+        headers: %{
+          RateLimitHeaders => Headers.to_map(RateLimitHeaders)
         }
       }
 
@@ -460,6 +474,12 @@ defmodule Rolodex.Processors.SwaggerTest do
                        schema: %{
                          "$ref" => "#/components/schemas/User"
                        }
+                     }
+                   },
+                   headers: %{
+                     "limited" => %{
+                       description: "Have you been rate limited",
+                       schema: %{type: :boolean}
                      }
                    },
                    description: "A single user entity response"

--- a/test/rolodex/request_body_test.exs
+++ b/test/rolodex/request_body_test.exs
@@ -97,6 +97,7 @@ defmodule Rolodex.RequestBodyTest do
     test "It serializes the request body as expected" do
       assert RequestBody.to_map(PaginatedUsersRequestBody) == %{
                desc: "A paginated list of user entities",
+               headers: nil,
                content: %{
                  "application/json" => %{
                    schema: %{

--- a/test/rolodex/response_test.exs
+++ b/test/rolodex/response_test.exs
@@ -11,7 +11,8 @@ defmodule Rolodex.ResponseTest do
     MultiResponse,
     User,
     Comment,
-    Parent
+    Parent,
+    PaginationHeaders
   }
 
   doctest Response
@@ -30,6 +31,22 @@ defmodule Rolodex.ResponseTest do
 
     test "Description is not required" do
       assert MultiResponse.__response__(:desc) == nil
+    end
+  end
+
+  describe "#set_headers/1 macro" do
+    test "It handles a shared headers module" do
+      assert UsersResponse.__response__(:headers) == %{
+               type: :ref,
+               ref: PaginationHeaders
+             }
+    end
+
+    test "It handles a bare map or kwl" do
+      assert ParentsResponse.__response__(:headers) == %{
+               "total" => %{type: :integer},
+               "per-page" => %{type: :integer, required: true}
+             }
     end
   end
 
@@ -95,6 +112,10 @@ defmodule Rolodex.ResponseTest do
     test "It serializes the response as expected" do
       assert Response.to_map(PaginatedUsersResponse) == %{
                desc: "A paginated list of user entities",
+               headers: %{
+                 type: :ref,
+                 ref: PaginationHeaders
+               },
                content: %{
                  "application/json" => %{
                    schema: %{
@@ -119,7 +140,7 @@ defmodule Rolodex.ResponseTest do
 
   describe "#get_refs/1" do
     test "It gets refs within a response module" do
-      assert Response.get_refs(MultiResponse) == [Comment, User]
+      assert Response.get_refs(MultiResponse) == [Comment, PaginationHeaders, User]
     end
   end
 end

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -105,7 +105,12 @@ defmodule Rolodex.RouteTest do
                },
                desc: "It's a test!",
                headers: %{
-                 "X-Request-Id" => %{type: :uuid, required: true}
+                 "total" => %{type: :integer, desc: "Total entries to be retrieved"},
+                 "per-page" => %{
+                   type: :integer,
+                   required: true,
+                   desc: "Total entries per page of results"
+                 }
                },
                body: %{type: :ref, ref: UserRequestBody},
                query_params: %{
@@ -153,7 +158,13 @@ defmodule Rolodex.RouteTest do
                },
                desc: "It's a test!",
                headers: %{
-                 "X-Request-Id" => %{type: :uuid, required: true}
+                 "X-Request-Id" => %{type: :uuid, required: true},
+                 "total" => %{type: :integer, desc: "Total entries to be retrieved"},
+                 "per-page" => %{
+                   type: :integer,
+                   required: true,
+                   desc: "Total entries per page of results"
+                 }
                },
                body: %{type: :ref, ref: UserRequestBody},
                query_params: %{

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -3,6 +3,7 @@ defmodule Rolodex.Mocks.TestController do
     UserRequestBody,
     UserResponse,
     PaginatedUsersResponse,
+    PaginationHeaders,
     ErrorResponse
   }
 
@@ -12,7 +13,7 @@ defmodule Rolodex.Mocks.TestController do
       TokenAuth: ["user.read"],
       OAuth: ["user.read"]
     ],
-    headers: %{"X-Request-Id" => %{type: :uuid, required: true}},
+    headers: PaginationHeaders,
     query_params: %{
       id: %{
         type: :string,
@@ -69,6 +70,7 @@ defmodule Rolodex.Mocks.TestController do
 
   @doc [
     body: %{id: :uuid},
+    headers: %{"X-Request-Id" => %{type: :uuid, required: true}},
     responses: %{
       200 => %{id: :uuid}
     }

--- a/test/support/mocks/headers.ex
+++ b/test/support/mocks/headers.ex
@@ -2,9 +2,9 @@ defmodule Rolodex.Mocks.PaginationHeaders do
   use Rolodex.Headers
 
   headers "PaginationHeaders" do
-    header("total", :integer, desc: "Total entries to be retrieved")
+    field("total", :integer, desc: "Total entries to be retrieved")
 
-    header("per-page", :integer,
+    field("per-page", :integer,
       desc: "Total entries per page of results",
       required: true
     )
@@ -15,6 +15,6 @@ defmodule Rolodex.Mocks.RateLimitHeaders do
   use Rolodex.Headers
 
   headers "RateLimitHeaders" do
-    header("limited", :boolean, desc: "Have you been rate limited")
+    field("limited", :boolean, desc: "Have you been rate limited")
   end
 end

--- a/test/support/mocks/headers.ex
+++ b/test/support/mocks/headers.ex
@@ -1,0 +1,20 @@
+defmodule Rolodex.Mocks.PaginationHeaders do
+  use Rolodex.Headers
+
+  headers "PaginationHeaders" do
+    header("total", :integer, desc: "Total entries to be retrieved")
+
+    header("per-page", :integer,
+      desc: "Total entries per page of results",
+      required: true
+    )
+  end
+end
+
+defmodule Rolodex.Mocks.RateLimitHeaders do
+  use Rolodex.Headers
+
+  headers "RateLimitHeaders" do
+    header("limited", :boolean, desc: "Have you been rate limited")
+  end
+end

--- a/test/support/mocks/responses.ex
+++ b/test/support/mocks/responses.ex
@@ -1,9 +1,10 @@
 defmodule Rolodex.Mocks.UserResponse do
   use Rolodex.Response
-  alias Rolodex.Mocks.User
+  alias Rolodex.Mocks.{User, RateLimitHeaders}
 
   response "UserResponse" do
     desc("A single user entity response")
+    headers(RateLimitHeaders)
 
     content "application/json" do
       schema(User)
@@ -14,10 +15,12 @@ end
 
 defmodule Rolodex.Mocks.UsersResponse do
   use Rolodex.Response
-  alias Rolodex.Mocks.User
+
+  alias Rolodex.Mocks.{PaginationHeaders, User}
 
   response "UsersResponse" do
     desc("A list of user entities")
+    headers(PaginationHeaders)
 
     content "application/json" do
       schema([User])
@@ -33,6 +36,11 @@ defmodule Rolodex.Mocks.ParentsResponse do
   response "ParentsResponse" do
     desc("A list of parent entities")
 
+    headers(%{
+      "total" => :integer,
+      "per-page" => %{type: :integer, required: true}
+    })
+
     content "application/json" do
       schema(:list, of: [Parent])
     end
@@ -41,10 +49,11 @@ end
 
 defmodule Rolodex.Mocks.PaginatedUsersResponse do
   use Rolodex.Response
-  alias Rolodex.Mocks.User
+  alias Rolodex.Mocks.{PaginationHeaders, User}
 
   response "PaginatedUsersResponse" do
     desc("A paginated list of user entities")
+    headers(PaginationHeaders)
 
     content "application/json" do
       schema(%{
@@ -75,9 +84,11 @@ end
 
 defmodule Rolodex.Mocks.MultiResponse do
   use Rolodex.Response
-  alias Rolodex.Mocks.{Comment, User}
+  alias Rolodex.Mocks.{Comment, PaginationHeaders, User}
 
   response "MultiResponse" do
+    headers(PaginationHeaders)
+
     content "application/json" do
       schema(User)
     end


### PR DESCRIPTION
We forgot to add support for defining response headers! That's the primary
addition this PR makes. In the process, we've also added support for defining
reusable headers via macros exported in the `Rolodex.Headers` module. The DSL
is very similar to what we've put together so far for schemas/responses/bodies.

Some highlights:

- You can now define shared headers via `Rolodex.Headers`
- Shared headers can be used in either responses OR route doc annotations (i.e.
  request headers)
- For OpenAPI 3, we never serialize headers as shared component refs b/c that
  isn't supported
- Removed documented support for nested schemas in parameters (path, query, header),
  since this isn't actually supported by OpenAPI 3. We weren't really testing against
  it anyway.