### PR TITLE
[PLATFORM-580] Support multiple response headers calls

### DIFF
--- a/lib/rolodex/request_body.ex
+++ b/lib/rolodex/request_body.ex
@@ -203,7 +203,7 @@ defmodule Rolodex.RequestBody do
       iex> Rolodex.RequestBody.to_map(MyRequestBody)
       %{
         desc: "A demo request body",
-        headers: nil,
+        headers: [],
         content: %{
           "application/json" => %{
             examples: %{

--- a/lib/rolodex/response.ex
+++ b/lib/rolodex/response.ex
@@ -71,7 +71,9 @@ defmodule Rolodex.Response do
 
   @doc """
   Sets headers to be included in the response. You can use a shared headers ref
-  defined via `Rolodex.Headers`, or just pass in a bare map or keyword list.
+  defined via `Rolodex.Headers`, or just pass in a bare map or keyword list. If
+  the macro is called multiple times, all headers passed in will be merged together
+  in the docs result.
 
   ## Examples
 
@@ -81,6 +83,7 @@ defmodule Rolodex.Response do
 
         response "MyResponse" do
           headers MyResponseHeaders
+          headers MyAdditionalResponseHeaders
         end
       end
 
@@ -237,9 +240,9 @@ defmodule Rolodex.Response do
       iex> Rolodex.Response.to_map(MyResponse)
       %{
         desc: "A demo response",
-        headers: %{
-          "X-Rate-Limited" => %{type: :boolean}
-        },
+        headers: [
+          %{"X-Rate-Limited" => %{type: :boolean}}
+        ],
         content: %{
           "application/json" => %{
             examples: %{

--- a/test/rolodex/request_body_test.exs
+++ b/test/rolodex/request_body_test.exs
@@ -97,7 +97,7 @@ defmodule Rolodex.RequestBodyTest do
     test "It serializes the request body as expected" do
       assert RequestBody.to_map(PaginatedUsersRequestBody) == %{
                desc: "A paginated list of user entities",
-               headers: nil,
+               headers: [],
                content: %{
                  "application/json" => %{
                    schema: %{

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -106,6 +106,40 @@ defmodule RolodexTest do
                      },
                      "description" => "An error response"
                    },
+                   "MultiResponse" => %{
+                     "description" => nil,
+                     "headers" => %{
+                       "total" => %{
+                         "description" => "Total entries to be retrieved",
+                         "schema" => %{"type" => "integer"}
+                       },
+                       "per-page" => %{
+                         "description" => "Total entries per page of results",
+                         "schema" => %{"type" => "integer"}
+                       },
+                       "limited" => %{
+                         "description" => "Have you been rate limited",
+                         "schema" => %{"type" => "boolean"}
+                       }
+                     },
+                     "content" => %{
+                       "application/json" => %{
+                         "examples" => %{},
+                         "schema" => %{
+                           "$ref" => "#/components/schemas/User"
+                         }
+                       },
+                       "application/lolsob" => %{
+                         "examples" => %{},
+                         "schema" => %{
+                           "type" => "array",
+                           "items" => %{
+                             "$ref" => "#/components/schemas/Comment"
+                           }
+                         }
+                       }
+                     }
+                   },
                    "PaginatedUsersResponse" => %{
                      "content" => %{
                        "application/json" => %{
@@ -406,6 +440,7 @@ defmodule RolodexTest do
                      "parameters" => [],
                      "responses" => %{
                        "200" => %{"$ref" => "#/components/responses/UserResponse"},
+                       "201" => %{"$ref" => "#/components/responses/MultiResponse"},
                        "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
                      },
                      "security" => [%{"JWTAuth" => []}],

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -2,6 +2,7 @@ defmodule Rolodex.Mocks.TestController do
   alias Rolodex.Mocks.{
     UserRequestBody,
     UserResponse,
+    MultiResponse,
     PaginatedUsersResponse,
     PaginationHeaders,
     ErrorResponse
@@ -45,6 +46,7 @@ defmodule Rolodex.Mocks.TestController do
       auth: :JWTAuth,
       responses: %{
         200 => UserResponse,
+        201 => MultiResponse,
         404 => ErrorResponse
       }
     ],

--- a/test/support/mocks/responses.ex
+++ b/test/support/mocks/responses.ex
@@ -84,10 +84,17 @@ end
 
 defmodule Rolodex.Mocks.MultiResponse do
   use Rolodex.Response
-  alias Rolodex.Mocks.{Comment, PaginationHeaders, User}
+
+  alias Rolodex.Mocks.{
+    Comment,
+    PaginationHeaders,
+    RateLimitHeaders,
+    User
+  }
 
   response "MultiResponse" do
     headers(PaginationHeaders)
+    headers(RateLimitHeaders)
 
     content "application/json" do
       schema(User)


### PR DESCRIPTION
Sometimes, you'll want to make multiple calls to the `headers/1` macro
when defining a response. This is often to use two or more shared
response headers modules for a specific response.

Via diff, we add support for multiple calls. All the headers passed
in to the response will ultimately be merged together when serialized.