### PR TITLE
Add render groups support

### DIFF
--- a/lib/mix/tasks/rolodex.gen.docs.ex
+++ b/lib/mix/tasks/rolodex.gen.docs.ex
@@ -5,8 +5,25 @@ defmodule Mix.Tasks.Rolodex.Gen.Docs do
 
   @doc false
   def run(_args) do
+    IO.puts("Rolodex is compiling your docs...\n")
+
     Application.get_all_env(:rolodex)[:module]
     |> Rolodex.Config.new()
     |> Rolodex.run()
+    |> log_result()
+  end
+
+  defp log_result(renders) do
+    renders
+    |> Enum.reduce([], fn
+      {:ok, _}, acc -> acc
+      {:error, err}, acc -> [err | acc]
+    end)
+    |> case do
+      [] -> IO.puts("Done!")
+      errs ->
+        IO.puts("Rolodex failed to compile some docs with the following errors:")
+        Enum.each(errs, &IO.inspect(&1))
+    end
   end
 end

--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -28,6 +28,11 @@ defmodule Rolodex.Config do
   list by default:
 
   - `spec/0` - Basic configuration for your Rolodex setup
+  - `render_groups_spec/0` - Definitions for render targets for your API docs. A
+  render group is combination of: (optional) route filters, a processor, a writer,
+  and options for the writer. You can specify more than one render group to create
+  multiple docs outputs for your API. By default, one render group will be defined
+  using the default values in `Rolodex.RenderGroupConfig`.
   - `auth_spec/0` - Definitions for shared auth patterns to be used in routes.
   Auth definitions should follow the OpenAPI pattern, but keys can use snake_case
   and will be converted to camelCase for the OpenAPI target.
@@ -42,19 +47,12 @@ defmodule Rolodex.Config do
   - `version` (required) - Your documentation's version
   - `default_content_type` (default: "application/json") - Default content type
   used for request body and response schemas
-  - `file_name` (default: "api.json") - The name of the output file with the processed
-  documentation
-  - `filters` (default: `:none`) - A list of maps or functions used to filter
-  out routes from your documentation. Filters are matched against `Rolodex.Route`
-  structs in `Rolodex.Route.matches_filter?/2`.
   - `locale` (default: `"en"`) - Locale key to use when processing descriptions
   - `pipelines` (default: `%{}`) - Map of pipeline configs. Used to set default
   parameter values for all routes in a pipeline. See `Rolodex.PipelineConfig`.
-  - `processor` (default: `Rolodex.Processors.Swagger`) - Module implementing
-  the `Rolodex.Processor` behaviour
+  - `render_groups` (default: `%Rolodex.RenderGroupConfig{}`) - List of render
+  groups.
   - `server_urls` (default: []) - List of base url(s) for your API paths
-  - `writer` (default: `Rolodex.Writers.FileWriter`) - Module implementing the
-  `Rolodex.Writer` behaviour to be used to write out the docs
 
   ## Full Example
 
@@ -67,12 +65,16 @@ defmodule Rolodex.Config do
             description: "My API's description",
             version: "1.0.0",
             default_content_type: "application/json+api",
-            file_name: "api.json",
-            filters: :none,
             locale: "en",
-            processor: MyProcessor,
             server_urls: ["https://myapp.io"],
             router: MyRouter
+          ]
+        end
+
+        def render_groups_spec() do
+          [
+            [writer_opts: [file_name: "api-public.json"]],
+            [writer_opts: [file_name: "api-private.json"]]
           ]
         end
 
@@ -110,51 +112,43 @@ defmodule Rolodex.Config do
       end
   """
 
-  alias Rolodex.PipelineConfig
+  alias Rolodex.{PipelineConfig, RenderGroupConfig}
 
   import Rolodex.Utils, only: [to_struct: 2, to_map_deep: 1]
 
   @enforce_keys [
     :description,
-    :file_name,
     :locale,
-    :processor,
+    :render_groups,
     :router,
     :title,
-    :version,
-    :writer
+    :version
   ]
 
   defstruct [
     :description,
     :pipelines,
+    :render_groups,
     :router,
     :title,
     :version,
     default_content_type: "application/json",
-    file_name: "api.json",
-    filters: :none,
     locale: "en",
-    processor: Rolodex.Processors.Swagger,
     auth: %{},
-    server_urls: [],
-    writer: Rolodex.Writers.FileWriter
+    server_urls: []
   ]
 
   @type t :: %__MODULE__{
           default_content_type: binary(),
           description: binary(),
-          file_name: binary(),
-          filters: [map() | (Rolodex.Route.t() -> boolean())] | :none,
           locale: binary(),
           pipelines: pipeline_configs() | nil,
-          processor: module(),
+          render_groups: [RenderGroupConfig.t()],
           router: module(),
           auth: map(),
           server_urls: [binary()],
           title: binary(),
-          version: binary(),
-          writer: module()
+          version: binary()
         }
 
   @type pipeline_configs :: %{
@@ -163,6 +157,8 @@ defmodule Rolodex.Config do
 
   @callback spec() :: keyword() | map()
   @callback pipelines_spec() :: keyword() | map()
+  @callback auth_spec() :: keyword() | map()
+  @callback render_groups_spec() :: list()
 
   defmacro __using__(_) do
     quote do
@@ -171,8 +167,12 @@ defmodule Rolodex.Config do
       def spec(), do: %{}
       def pipelines_spec(), do: %{}
       def auth_spec(), do: %{}
+      def render_groups_spec(), do: [[]]
 
-      defoverridable spec: 0, pipelines_spec: 0, auth_spec: 0
+      defoverridable spec: 0,
+                     pipelines_spec: 0,
+                     auth_spec: 0,
+                     render_groups_spec: 0
     end
   end
 
@@ -182,6 +182,7 @@ defmodule Rolodex.Config do
     |> Map.new()
     |> set_pipelines_config(module)
     |> set_auth_config(module)
+    |> set_render_groups_config(module)
     |> to_struct(__MODULE__)
   end
 
@@ -193,8 +194,49 @@ defmodule Rolodex.Config do
     Map.put(opts, :pipelines, pipelines)
   end
 
-  def set_auth_config(opts, module),
+  defp set_auth_config(opts, module),
     do: Map.put(opts, :auth, module.auth_spec() |> to_map_deep())
+
+  defp set_render_groups_config(opts, module) do
+    groups = module.render_groups_spec() |> Enum.map(&RenderGroupConfig.new/1)
+    Map.put(opts, :render_groups, groups)
+  end
+end
+
+defmodule Rolodex.RenderGroupConfig do
+  @moduledoc """
+  Configuration for a render group, a serialization target for your docs. You can
+  specify one or more render groups via `Rolodex.Config` to render docs output(s)
+  for your API.
+
+  ## Options
+
+  - `filters` (default: `:none`) - A list of maps or functions used to filter
+  out routes from your documentation. Filters are invoked in
+  `Rolodex.Route.matches_filter?/2`. If the match returns true, the route will be
+  filtered out of the docs result for this render group.
+  - `processor` (default: `Rolodex.Processors.Swagger`) - Module implementing
+  the `Rolodex.Processor` behaviour
+  - `writer` (default: `Rolodex.Writers.FileWriter`) - Module implementing the
+  `Rolodex.Writer` behaviour to be used to write out the docs
+  - `writer_opts` (default: `[file_name: "api.json"]`) - Options keyword list
+  passed into the writer behaviour.
+  """
+
+  defstruct filters: :none,
+            processor: Rolodex.Processors.Swagger,
+            writer: Rolodex.Writers.FileWriter,
+            writer_opts: [file_name: "api.json"]
+
+  @type t :: %__MODULE__{
+          filters: [map() | (Rolodex.Route.t() -> boolean())] | :none,
+          processor: module(),
+          writer: module(),
+          writer_opts: keyword()
+        }
+
+  @spec new(list() | map()) :: t()
+  def new(params \\ []), do: struct(__MODULE__, params)
 end
 
 defmodule Rolodex.PipelineConfig do

--- a/lib/rolodex/route.ex
+++ b/lib/rolodex/route.ex
@@ -402,10 +402,10 @@ defmodule Rolodex.Route do
   @doc """
   Checks to see if the given route matches any filter(s) stored in `Rolodex.Config`.
   """
-  @spec matches_filter?(t(), Rolodex.Config.t()) :: boolean()
-  def matches_filter?(route, config)
+  @spec matches_filter?(t(), any()) :: boolean()
+  def matches_filter?(route, filters)
 
-  def matches_filter?(route, %Config{filters: filters}) when is_list(filters) do
+  def matches_filter?(route, filters) when is_list(filters) do
     Enum.any?(filters, fn
       filter_opts when is_map(filter_opts) ->
         keys = Map.keys(filter_opts)

--- a/lib/rolodex/writers/file_writer.ex
+++ b/lib/rolodex/writers/file_writer.ex
@@ -1,11 +1,9 @@
 defmodule Rolodex.Writers.FileWriter do
   @behaviour Rolodex.Writer
 
-  alias Rolodex.Config
-
   @impl Rolodex.Writer
-  def init(config) do
-    with {:ok, file_name} <- fetch_file_name(config),
+  def init(opts) do
+    with {:ok, file_name} <- fetch_file_name(opts),
          {:ok, cwd} <- File.cwd(),
          full_path <- Path.join([cwd, file_name]),
          :ok <- File.touch(full_path) do
@@ -23,11 +21,14 @@ defmodule Rolodex.Writers.FileWriter do
     File.close(io_device)
   end
 
-  defp fetch_file_name(%Config{file_name: file_name}) do
-    case file_name do
-      "" -> {:error, :file_name_missing}
-      nil -> {:error, :file_name_missing}
-      path -> {:ok, path}
-    end
+  defp fetch_file_name(opts) when is_list(opts) do
+    opts
+    |> Map.new()
+    |> fetch_file_name()
   end
+
+  defp fetch_file_name(%{file_name: name}) when is_binary(name) and name != "",
+    do: {:ok, name}
+
+  defp fetch_file_name(_), do: {:error, :file_name_missing}
 end

--- a/lib/rolodex/writers/writer.ex
+++ b/lib/rolodex/writers/writer.ex
@@ -11,7 +11,7 @@ defmodule Rolodex.Writer do
   @doc """
   Returns an open `IO.device()` for writing.
   """
-  @callback init(Rolodex.Config.t()) :: {:ok, IO.device()} | {:error, any}
+  @callback init(list() | map()) :: {:ok, IO.device()} | {:error, any}
 
   @doc """
   Closes the given `IO.device()`.

--- a/test/rolodex/config_test.exs
+++ b/test/rolodex/config_test.exs
@@ -1,7 +1,7 @@
 defmodule Rolodex.ConfigTest do
   use ExUnit.Case
 
-  alias Rolodex.{Config, PipelineConfig}
+  alias Rolodex.{Config, PipelineConfig, RenderGroupConfig}
 
   defmodule BasicConfig do
     use Rolodex.Config
@@ -25,6 +25,13 @@ defmodule Rolodex.ConfigTest do
         title: "BasicConfig",
         version: "0.0.1",
         router: MyRouter
+      ]
+    end
+
+    def render_groups_spec() do
+      [
+        [writer_opts: [file_name: "api-public.json"]],
+        [writer_opts: [file_name: "api-private.json"]]
       ]
     end
 
@@ -66,21 +73,18 @@ defmodule Rolodex.ConfigTest do
     test "It parses a basic config with no writer and pipeline overrides" do
       assert Config.new(BasicConfig) == %Config{
                description: "Hello world",
-               file_name: "api.json",
                locale: "en",
                pipelines: %{},
-               processor: Rolodex.Processors.Swagger,
                title: "BasicConfig",
                version: "0.0.1",
                router: MyRouter,
-               writer: Rolodex.Writers.FileWriter
+               render_groups: [%RenderGroupConfig{}]
              }
     end
 
     test "It parses a full config with writer and pipeline overrides" do
       assert Config.new(FullConfig) == %Config{
                description: "Hello world",
-               file_name: "api.json",
                locale: "en",
                pipelines: %{
                  api: PipelineConfig.new(headers: ["X-Request-ID": :uuid], auth: :JWTAuth)
@@ -106,11 +110,13 @@ defmodule Rolodex.ConfigTest do
                    }
                  }
                },
-               processor: Rolodex.Processors.Swagger,
                title: "BasicConfig",
                version: "0.0.1",
                router: MyRouter,
-               writer: Rolodex.Writers.FileWriter
+               render_groups: [
+                 %RenderGroupConfig{writer_opts: [file_name: "api-public.json"]},
+                 %RenderGroupConfig{writer_opts: [file_name: "api-private.json"]}
+               ]
              }
     end
   end

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -45,41 +45,36 @@ defmodule Rolodex.RouteTest do
         TestRouter.__routes__()
         |> Enum.map(&Route.new(&1, config))
 
-      assert routes |> Enum.at(0) |> Route.matches_filter?(config) == false
-      assert routes |> Enum.at(1) |> Route.matches_filter?(config) == false
+      refute routes |> Enum.at(0) |> Route.matches_filter?(:none)
+      refute routes |> Enum.at(1) |> Route.matches_filter?(:none)
     end
 
     test "Returns true when for a route that matches a filter map", %{config: config} do
-      config = %Config{config | filters: [%{path: "/api/demo", verb: :get}]}
-
       routes =
         TestRouter.__routes__()
         |> Enum.map(&Route.new(&1, config))
 
-      assert routes |> Enum.at(0) |> Route.matches_filter?(config) == true
-      assert routes |> Enum.at(1) |> Route.matches_filter?(config) == false
+      assert routes |> Enum.at(0) |> Route.matches_filter?([%{path: "/api/demo", verb: :get}])
+      refute routes |> Enum.at(1) |> Route.matches_filter?([%{path: "/api/demo", verb: :get}])
     end
 
     test "Returns true for a route that matches a filter function", %{config: config} do
-      config = %Config{
-        config
-        | filters: [
-            fn
-              %Route{path: "/api/demo/:id", verb: :post} ->
-                true
+      filters = [
+        fn
+          %Route{path: "/api/demo/:id", verb: :post} ->
+            true
 
-              _ ->
-                false
-            end
-          ]
-      }
+          _ ->
+            false
+        end
+      ]
 
       routes =
         TestRouter.__routes__()
         |> Enum.map(&Route.new(&1, config))
 
-      assert routes |> Enum.at(0) |> Route.matches_filter?(config) == false
-      assert routes |> Enum.at(1) |> Route.matches_filter?(config) == true
+      refute routes |> Enum.at(0) |> Route.matches_filter?(filters)
+      assert routes |> Enum.at(1) |> Route.matches_filter?(filters)
     end
   end
 

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -1,40 +1,40 @@
 defmodule RolodexTest do
   use ExUnit.Case
+
   import ExUnit.CaptureIO
 
-  alias Rolodex.{Config, Route}
-
-  alias Rolodex.Mocks.{
-    Comment,
-    FirstNested,
-    NestedDemo,
-    NotFound,
-    Parent,
-    SecondNested,
-    TestRouter,
-    User,
-    UserResponse,
-    PaginatedUsersResponse,
-    ErrorResponse,
-    UserRequestBody,
-    PaginationHeaders,
-    RateLimitHeaders
-  }
-
-  defmodule ConfigNoFilters do
-    use Rolodex.Config
-    def spec(), do: [router: TestRouter]
-  end
-
-  defmodule ConfigWithFilters do
+  defmodule BadConfig do
     use Rolodex.Config
 
     def spec() do
       [
-        router: TestRouter,
-        filters: [%{path: "/api/demo/:id", verb: :delete}],
-        writer: Rolodex.Writers.Mock,
+        router: Rolodex.Mocks.TestRouter,
         server_urls: ["https://api.example.com"]
+      ]
+    end
+
+    def render_groups_spec() do
+      [[writer_opts: []]]
+    end
+  end
+
+  defmodule TestConfig do
+    use Rolodex.Config
+
+    def spec() do
+      [
+        router: Rolodex.Mocks.TestRouter,
+        server_urls: ["https://api.example.com"]
+      ]
+    end
+
+    def render_groups_spec() do
+      [
+        [writer: Rolodex.Writers.Mock],
+        [
+          filters: [%{path: "/api/demo/:id", verb: :delete}],
+          writer: Rolodex.Writers.Mock
+        ]
       ]
     end
 
@@ -63,358 +63,368 @@ defmodule RolodexTest do
     end
   end
 
-  describe "#run/1" do
-    test "Generates documentation and writes out to destination" do
-      result =
-        capture_io(fn ->
-          ConfigWithFilters
-          |> Config.new()
-          |> Rolodex.run()
-        end)
-        |> Jason.decode!()
+  defp get_result(renders, idx) do
+    renders
+    |> Enum.at(idx)
+    |> elem(1)
+    |> Jason.decode!()
+  end
 
-      assert result == %{
-               "components" => %{
-                 "requestBodies" => %{
-                   "UserRequestBody" => %{
-                     "content" => %{
-                       "application/json" => %{
-                         "examples" => %{
-                           "request" => %{"value" => %{"id" => "1"}}
-                         },
-                         "schema" => %{
-                           "$ref" => "#/components/schemas/User"
-                         }
-                       }
-                     },
-                     "description" => "A single user entity request body"
-                   }
-                 },
-                 "responses" => %{
-                   "ErrorResponse" => %{
-                     "content" => %{
-                       "application/json" => %{
-                         "examples" => %{},
-                         "schema" => %{
-                           "properties" => %{
-                             "message" => %{"type" => "string"},
-                             "status" => %{"type" => "integer"}
+  describe "#run/1" do
+    test "Returns an error when config is malformed" do
+      capture_io(fn ->
+        renders =
+          BadConfig
+          |> Rolodex.Config.new()
+          |> Rolodex.run()
+
+        assert renders |> Enum.at(0) == {:error, {:error, :file_name_missing}}
+      end)
+    end
+
+    test "Generates documentation and writes out to destination for multiple render groups" do
+      capture_io(fn ->
+        renders =
+          TestConfig
+          |> Rolodex.Config.new()
+          |> Rolodex.run()
+
+        assert length(renders) == 2
+
+        assert get_result(renders, 0) == %{
+                 "components" => %{
+                   "requestBodies" => %{
+                     "UserRequestBody" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{
+                             "request" => %{"value" => %{"id" => "1"}}
                            },
-                           "type" => "object"
+                           "schema" => %{
+                             "$ref" => "#/components/schemas/User"
+                           }
                          }
-                       }
-                     },
-                     "description" => "An error response"
+                       },
+                       "description" => "A single user entity request body"
+                     }
                    },
-                   "MultiResponse" => %{
-                     "description" => nil,
-                     "headers" => %{
-                       "total" => %{
-                         "description" => "Total entries to be retrieved",
-                         "schema" => %{"type" => "integer"}
-                       },
-                       "per-page" => %{
-                         "description" => "Total entries per page of results",
-                         "schema" => %{"type" => "integer"}
-                       },
-                       "limited" => %{
-                         "description" => "Have you been rate limited",
-                         "schema" => %{"type" => "boolean"}
-                       }
-                     },
-                     "content" => %{
-                       "application/json" => %{
-                         "examples" => %{},
-                         "schema" => %{
-                           "$ref" => "#/components/schemas/User"
+                   "responses" => %{
+                     "ErrorResponse" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{},
+                           "schema" => %{
+                             "properties" => %{
+                               "message" => %{"type" => "string"},
+                               "status" => %{"type" => "integer"}
+                             },
+                             "type" => "object"
+                           }
                          }
                        },
-                       "application/lolsob" => %{
-                         "examples" => %{},
-                         "schema" => %{
+                       "description" => "An error response"
+                     },
+                     "MultiResponse" => %{
+                       "description" => nil,
+                       "headers" => %{
+                         "total" => %{
+                           "description" => "Total entries to be retrieved",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         "per-page" => %{
+                           "description" => "Total entries per page of results",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         "limited" => %{
+                           "description" => "Have you been rate limited",
+                           "schema" => %{"type" => "boolean"}
+                         }
+                       },
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{},
+                           "schema" => %{
+                             "$ref" => "#/components/schemas/User"
+                           }
+                         },
+                         "application/lolsob" => %{
+                           "examples" => %{},
+                           "schema" => %{
+                             "type" => "array",
+                             "items" => %{
+                               "$ref" => "#/components/schemas/Comment"
+                             }
+                           }
+                         }
+                       }
+                     },
+                     "PaginatedUsersResponse" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{
+                             "response" => %{"value" => [%{"id" => "1"}]}
+                           },
+                           "schema" => %{
+                             "properties" => %{
+                               "page" => %{"type" => "integer"},
+                               "total" => %{"type" => "integer"},
+                               "users" => %{
+                                 "items" => %{
+                                   "$ref" => "#/components/schemas/User"
+                                 },
+                                 "type" => "array"
+                               }
+                             },
+                             "type" => "object"
+                           }
+                         }
+                       },
+                       "headers" => %{
+                         "total" => %{
+                           "description" => "Total entries to be retrieved",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         "per-page" => %{
+                           "description" => "Total entries per page of results",
+                           "schema" => %{"type" => "integer"}
+                         }
+                       },
+                       "description" => "A paginated list of user entities"
+                     },
+                     "UserResponse" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{
+                             "response" => %{"value" => %{"id" => "1"}}
+                           },
+                           "schema" => %{
+                             "$ref" => "#/components/schemas/User"
+                           }
+                         }
+                       },
+                       "headers" => %{
+                         "limited" => %{
+                           "description" => "Have you been rate limited",
+                           "schema" => %{"type" => "boolean"}
+                         }
+                       },
+                       "description" => "A single user entity response"
+                     }
+                   },
+                   "schemas" => %{
+                     "Comment" => %{
+                       "description" => "A comment record",
+                       "properties" => %{
+                         "id" => %{
+                           "format" => "uuid",
+                           "type" => "string",
+                           "description" => "The comment id"
+                         },
+                         "text" => %{
+                           "type" => "string"
+                         }
+                       },
+                       "type" => "object"
+                     },
+                     "NotFound" => %{
+                       "description" => "Not found response",
+                       "properties" => %{
+                         "message" => %{
+                           "type" => "string"
+                         }
+                       },
+                       "type" => "object"
+                     },
+                     "Parent" => %{
+                       "properties" => %{"child" => %{"$ref" => "#/components/schemas/User"}},
+                       "type" => "object"
+                     },
+                     "User" => %{
+                       "type" => "object",
+                       "description" => "A user record",
+                       "required" => ["id", "email"],
+                       "properties" => %{
+                         "id" => %{
+                           "type" => "string",
+                           "format" => "uuid",
+                           "description" => "The id of the user"
+                         },
+                         "email" => %{
+                           "type" => "string",
+                           "description" => "The email of the user"
+                         },
+                         "comment" => %{
+                           "$ref" => "#/components/schemas/Comment"
+                         },
+                         "comments" => %{
                            "type" => "array",
                            "items" => %{
                              "$ref" => "#/components/schemas/Comment"
                            }
-                         }
-                       }
-                     }
-                   },
-                   "PaginatedUsersResponse" => %{
-                     "content" => %{
-                       "application/json" => %{
-                         "examples" => %{
-                           "response" => %{"value" => [%{"id" => "1"}]}
                          },
-                         "schema" => %{
-                           "properties" => %{
-                             "page" => %{"type" => "integer"},
-                             "total" => %{"type" => "integer"},
-                             "users" => %{
-                               "items" => %{
-                                 "$ref" => "#/components/schemas/User"
+                         "comments_of_many_types" => %{
+                           "type" => "array",
+                           "description" => "List of text or comment",
+                           "items" => %{
+                             "oneOf" => [
+                               %{
+                                 "type" => "string"
                                },
-                               "type" => "array"
-                             }
-                           },
-                           "type" => "object"
-                         }
-                       }
-                     },
-                     "headers" => %{
-                       "total" => %{
-                         "description" => "Total entries to be retrieved",
-                         "schema" => %{"type" => "integer"}
-                       },
-                       "per-page" => %{
-                         "description" => "Total entries per page of results",
-                         "schema" => %{"type" => "integer"}
-                       }
-                     },
-                     "description" => "A paginated list of user entities"
-                   },
-                   "UserResponse" => %{
-                     "content" => %{
-                       "application/json" => %{
-                         "examples" => %{
-                           "response" => %{"value" => %{"id" => "1"}}
+                               %{
+                                 "$ref" => "#/components/schemas/Comment"
+                               }
+                             ]
+                           }
                          },
-                         "schema" => %{
-                           "$ref" => "#/components/schemas/User"
-                         }
-                       }
-                     },
-                     "headers" => %{
-                       "limited" => %{
-                         "description" => "Have you been rate limited",
-                         "schema" => %{"type" => "boolean"}
-                       }
-                     },
-                     "description" => "A single user entity response"
-                   }
-                 },
-                 "schemas" => %{
-                   "Comment" => %{
-                     "description" => "A comment record",
-                     "properties" => %{
-                       "id" => %{
-                         "format" => "uuid",
-                         "type" => "string",
-                         "description" => "The comment id"
-                       },
-                       "text" => %{
-                         "type" => "string"
-                       }
-                     },
-                     "type" => "object"
-                   },
-                   "NotFound" => %{
-                     "description" => "Not found response",
-                     "properties" => %{
-                       "message" => %{
-                         "type" => "string"
-                       }
-                     },
-                     "type" => "object"
-                   },
-                   "Parent" => %{
-                     "properties" => %{"child" => %{"$ref" => "#/components/schemas/User"}},
-                     "type" => "object"
-                   },
-                   "User" => %{
-                     "type" => "object",
-                     "description" => "A user record",
-                     "required" => ["id", "email"],
-                     "properties" => %{
-                       "id" => %{
-                         "type" => "string",
-                         "format" => "uuid",
-                         "description" => "The id of the user"
-                       },
-                       "email" => %{
-                         "type" => "string",
-                         "description" => "The email of the user"
-                       },
-                       "comment" => %{
-                         "$ref" => "#/components/schemas/Comment"
-                       },
-                       "comments" => %{
-                         "type" => "array",
-                         "items" => %{
-                           "$ref" => "#/components/schemas/Comment"
-                         }
-                       },
-                       "comments_of_many_types" => %{
-                         "type" => "array",
-                         "description" => "List of text or comment",
-                         "items" => %{
+                         "multi" => %{
                            "oneOf" => [
                              %{
                                "type" => "string"
                              },
-                             %{
-                               "$ref" => "#/components/schemas/Comment"
-                             }
+                             %{"$ref" => "#/components/schemas/NotFound"}
                            ]
-                         }
-                       },
-                       "multi" => %{
-                         "oneOf" => [
-                           %{
-                             "type" => "string"
-                           },
-                           %{"$ref" => "#/components/schemas/NotFound"}
-                         ]
-                       },
-                       "parent" => %{
-                         "$ref" => "#/components/schemas/Parent"
-                       },
-                       "private" => %{
-                         "type" => "boolean"
-                       },
-                       "archived" => %{
-                         "type" => "boolean"
-                       },
-                       "active" => %{
-                         "type" => "boolean"
-                       }
-                     }
-                   }
-                 },
-                 "securitySchemes" => %{
-                   "JWTAuth" => %{
-                     "type" => "http",
-                     "scheme" => "bearer"
-                   },
-                   "TokenAuth" => %{"type" => "oauth2"},
-                   "OAuth" => %{
-                     "type" => "oauth2",
-                     "flows" => %{
-                       "authorizationCode" => %{
-                         "authorizationUrl" => "https://applications.frame.io/oauth2/authorize",
-                         "tokenUrl" => "https://applications.frame.io/oauth2/token",
-                         "scopes" => [
-                           "user.read",
-                           "account.read",
-                           "account.write"
-                         ]
-                       }
-                     }
-                   }
-                 }
-               },
-               "info" => %{"description" => nil, "title" => nil, "version" => nil},
-               "openapi" => "3.0.0",
-               "servers" => [%{"url" => "https://api.example.com"}],
-               "paths" => %{
-                 "/api/demo" => %{
-                   "get" => %{
-                     "operationId" => "",
-                     "security" => [
-                       %{"JWTAuth" => []},
-                       %{"OAuth" => ["user.read"]},
-                       %{"TokenAuth" => ["user.read"]}
-                     ],
-                     "parameters" => [
-                       %{
-                         "in" => "header",
-                         "name" => "per-page",
-                         "required" => true,
-                         "description" => "Total entries per page of results",
-                         "schema" => %{"type" => "integer"}
-                       },
-                       %{
-                         "in" => "header",
-                         "name" => "total",
-                         "description" => "Total entries to be retrieved",
-                         "schema" => %{"type" => "integer"}
-                       },
-                       %{
-                         "in" => "path",
-                         "name" => "account_id",
-                         "schema" => %{"format" => "uuid", "type" => "string"}
-                       },
-                       %{
-                         "in" => "query",
-                         "name" => "id",
-                         "schema" => %{
-                           "default" => 2,
-                           "maximum" => 10,
-                           "minimum" => 0,
-                           "type" => "string"
-                         }
-                       },
-                       %{
-                         "in" => "query",
-                         "name" => "update",
-                         "schema" => %{
+                         },
+                         "parent" => %{
+                           "$ref" => "#/components/schemas/Parent"
+                         },
+                         "private" => %{
+                           "type" => "boolean"
+                         },
+                         "archived" => %{
+                           "type" => "boolean"
+                         },
+                         "active" => %{
                            "type" => "boolean"
                          }
                        }
-                     ],
-                     "requestBody" => %{
-                       "$ref" => "#/components/requestBodies/UserRequestBody"
+                     }
+                   },
+                   "securitySchemes" => %{
+                     "JWTAuth" => %{
+                       "type" => "http",
+                       "scheme" => "bearer"
                      },
-                     "responses" => %{
-                       "200" => %{
-                         "$ref" => "#/components/responses/UserResponse"
-                       },
-                       "201" => %{
-                         "$ref" => "#/components/responses/PaginatedUsersResponse"
-                       },
-                       "404" => %{
-                         "$ref" => "#/components/responses/ErrorResponse"
+                     "TokenAuth" => %{"type" => "oauth2"},
+                     "OAuth" => %{
+                       "type" => "oauth2",
+                       "flows" => %{
+                         "authorizationCode" => %{
+                           "authorizationUrl" => "https://applications.frame.io/oauth2/authorize",
+                           "tokenUrl" => "https://applications.frame.io/oauth2/token",
+                           "scopes" => [
+                             "user.read",
+                             "account.read",
+                             "account.write"
+                           ]
+                         }
                        }
-                     },
-                     "summary" => "It's a test!",
-                     "tags" => ["foo", "bar"]
+                     }
                    }
                  },
-                 "/api/demo/{id}" => %{
-                   "post" => %{
-                     "operationId" => "",
-                     "security" => [%{"JWTAuth" => []}],
-                     "parameters" => [
-                       %{
-                         "in" => "header",
-                         "name" => "X-Request-Id",
-                         "schema" => %{
-                           "type" => "string"
-                         }
-                       }
-                     ],
-                     "responses" => %{},
-                     "summary" => "",
-                     "tags" => []
-                   },
-                   "put" => %{
-                     "operationId" => "",
-                     "security" => [],
-                     "parameters" => [
-                       %{
-                         "in" => "header",
-                         "name" => "X-Request-Id",
-                         "required" => true,
-                         "schema" => %{"format" => "uuid", "type" => "string"}
-                       }
-                     ],
-                     "requestBody" => %{
-                       "content" => %{
-                         "application/json" => %{
+                 "info" => %{"description" => nil, "title" => nil, "version" => nil},
+                 "openapi" => "3.0.0",
+                 "servers" => [%{"url" => "https://api.example.com"}],
+                 "paths" => %{
+                   "/api/demo" => %{
+                     "get" => %{
+                       "operationId" => "",
+                       "security" => [
+                         %{"JWTAuth" => []},
+                         %{"OAuth" => ["user.read"]},
+                         %{"TokenAuth" => ["user.read"]}
+                       ],
+                       "parameters" => [
+                         %{
+                           "in" => "header",
+                           "name" => "per-page",
+                           "required" => true,
+                           "description" => "Total entries per page of results",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         %{
+                           "in" => "header",
+                           "name" => "total",
+                           "description" => "Total entries to be retrieved",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "account_id",
+                           "schema" => %{"format" => "uuid", "type" => "string"}
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "id",
                            "schema" => %{
-                             "type" => "object",
-                             "properties" => %{
-                               "id" => %{
-                                 "type" => "string",
-                                 "format" => "uuid"
-                               }
-                             }
+                             "default" => 2,
+                             "maximum" => 10,
+                             "minimum" => 0,
+                             "type" => "string"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "update",
+                           "schema" => %{
+                             "type" => "boolean"
                            }
                          }
-                       }
+                       ],
+                       "requestBody" => %{
+                         "$ref" => "#/components/requestBodies/UserRequestBody"
+                       },
+                       "responses" => %{
+                         "200" => %{
+                           "$ref" => "#/components/responses/UserResponse"
+                         },
+                         "201" => %{
+                           "$ref" => "#/components/responses/PaginatedUsersResponse"
+                         },
+                         "404" => %{
+                           "$ref" => "#/components/responses/ErrorResponse"
+                         }
+                       },
+                       "summary" => "It's a test!",
+                       "tags" => ["foo", "bar"]
+                     }
+                   },
+                   "/api/demo/{id}" => %{
+                     "delete" => %{
+                       "operationId" => "",
+                       "parameters" => [],
+                       "responses" => %{},
+                       "security" => [],
+                       "summary" => "",
+                       "tags" => []
                      },
-                     "responses" => %{
-                       "200" => %{
+                     "post" => %{
+                       "operationId" => "",
+                       "security" => [%{"JWTAuth" => []}],
+                       "parameters" => [
+                         %{
+                           "in" => "header",
+                           "name" => "X-Request-Id",
+                           "schema" => %{
+                             "type" => "string"
+                           }
+                         }
+                       ],
+                       "responses" => %{},
+                       "summary" => "",
+                       "tags" => []
+                     },
+                     "put" => %{
+                       "operationId" => "",
+                       "security" => [],
+                       "parameters" => [
+                         %{
+                           "in" => "header",
+                           "name" => "X-Request-Id",
+                           "required" => true,
+                           "schema" => %{"format" => "uuid", "type" => "string"}
+                         }
+                       ],
+                       "requestBody" => %{
                          "content" => %{
                            "application/json" => %{
                              "schema" => %{
@@ -428,178 +438,463 @@ defmodule RolodexTest do
                              }
                            }
                          }
-                       }
-                     },
-                     "summary" => "",
-                     "tags" => []
-                   }
-                 },
-                 "/api/multi" => %{
-                   "get" => %{
-                     "operationId" => "",
-                     "parameters" => [],
-                     "responses" => %{
-                       "200" => %{"$ref" => "#/components/responses/UserResponse"},
-                       "201" => %{"$ref" => "#/components/responses/MultiResponse"},
-                       "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
-                     },
-                     "security" => [%{"JWTAuth" => []}],
-                     "summary" => "It's an action used for multiple routes",
-                     "tags" => []
-                   }
-                 },
-                 "/api/nested/{nested_id}/multi" => %{
-                   "get" => %{
-                     "operationId" => "",
-                     "parameters" => [
-                       %{
-                         "in" => "path",
-                         "name" => "nested_id",
-                         "required" => true,
-                         "schema" => %{"format" => "uuid", "type" => "string"}
-                       }
-                     ],
-                     "responses" => %{
-                       "200" => %{"$ref" => "#/components/responses/UserResponse"},
-                       "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
-                     },
-                     "security" => [%{"JWTAuth" => []}],
-                     "summary" => "It's an action used for multiple routes",
-                     "tags" => []
+                       },
+                       "responses" => %{
+                         "200" => %{
+                           "content" => %{
+                             "application/json" => %{
+                               "schema" => %{
+                                 "type" => "object",
+                                 "properties" => %{
+                                   "id" => %{
+                                     "type" => "string",
+                                     "format" => "uuid"
+                                   }
+                                 }
+                               }
+                             }
+                           }
+                         }
+                       },
+                       "summary" => "",
+                       "tags" => []
+                     }
+                   },
+                   "/api/multi" => %{
+                     "get" => %{
+                       "operationId" => "",
+                       "parameters" => [],
+                       "responses" => %{
+                         "200" => %{"$ref" => "#/components/responses/UserResponse"},
+                         "201" => %{"$ref" => "#/components/responses/MultiResponse"},
+                         "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
+                       },
+                       "security" => [%{"JWTAuth" => []}],
+                       "summary" => "It's an action used for multiple routes",
+                       "tags" => []
+                     }
+                   },
+                   "/api/nested/{nested_id}/multi" => %{
+                     "get" => %{
+                       "operationId" => "",
+                       "parameters" => [
+                         %{
+                           "in" => "path",
+                           "name" => "nested_id",
+                           "required" => true,
+                           "schema" => %{"format" => "uuid", "type" => "string"}
+                         }
+                       ],
+                       "responses" => %{
+                         "200" => %{"$ref" => "#/components/responses/UserResponse"},
+                         "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
+                       },
+                       "security" => [%{"JWTAuth" => []}],
+                       "summary" => "It's an action used for multiple routes",
+                       "tags" => []
+                     }
                    }
                  }
                }
-             }
-    end
-  end
 
-  describe "#generate_routes/1" do
-    test "Generates a list of %Route{} structs for the given router" do
-      result =
-        ConfigNoFilters
-        |> Config.new()
-        |> Rolodex.generate_routes()
-
-      assert result |> Enum.at(0) == %Route{
-               auth: %{
-                 JWTAuth: [],
-                 TokenAuth: ["user.read"],
-                 OAuth: ["user.read"]
-               },
-               body: %{type: :ref, ref: UserRequestBody},
-               desc: "It's a test!",
-               headers: %{
-                 "total" => %{type: :integer, desc: "Total entries to be retrieved"},
-                 "per-page" => %{
-                   type: :integer,
-                   required: true,
-                   desc: "Total entries per page of results"
-                 }
-               },
-               metadata: %{public: true},
-               path: "/api/demo",
-               path_params: %{
-                 account_id: %{type: :uuid}
-               },
-               query_params: %{
-                 id: %{
-                   type: :string,
-                   maximum: 10,
-                   minimum: 0,
-                   required: false,
-                   default: 2
+        assert get_result(renders, 1) == %{
+                 "components" => %{
+                   "requestBodies" => %{
+                     "UserRequestBody" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{
+                             "request" => %{"value" => %{"id" => "1"}}
+                           },
+                           "schema" => %{
+                             "$ref" => "#/components/schemas/User"
+                           }
+                         }
+                       },
+                       "description" => "A single user entity request body"
+                     }
+                   },
+                   "responses" => %{
+                     "ErrorResponse" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{},
+                           "schema" => %{
+                             "properties" => %{
+                               "message" => %{"type" => "string"},
+                               "status" => %{"type" => "integer"}
+                             },
+                             "type" => "object"
+                           }
+                         }
+                       },
+                       "description" => "An error response"
+                     },
+                     "MultiResponse" => %{
+                       "description" => nil,
+                       "headers" => %{
+                         "total" => %{
+                           "description" => "Total entries to be retrieved",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         "per-page" => %{
+                           "description" => "Total entries per page of results",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         "limited" => %{
+                           "description" => "Have you been rate limited",
+                           "schema" => %{"type" => "boolean"}
+                         }
+                       },
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{},
+                           "schema" => %{
+                             "$ref" => "#/components/schemas/User"
+                           }
+                         },
+                         "application/lolsob" => %{
+                           "examples" => %{},
+                           "schema" => %{
+                             "type" => "array",
+                             "items" => %{
+                               "$ref" => "#/components/schemas/Comment"
+                             }
+                           }
+                         }
+                       }
+                     },
+                     "PaginatedUsersResponse" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{
+                             "response" => %{"value" => [%{"id" => "1"}]}
+                           },
+                           "schema" => %{
+                             "properties" => %{
+                               "page" => %{"type" => "integer"},
+                               "total" => %{"type" => "integer"},
+                               "users" => %{
+                                 "items" => %{
+                                   "$ref" => "#/components/schemas/User"
+                                 },
+                                 "type" => "array"
+                               }
+                             },
+                             "type" => "object"
+                           }
+                         }
+                       },
+                       "headers" => %{
+                         "total" => %{
+                           "description" => "Total entries to be retrieved",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         "per-page" => %{
+                           "description" => "Total entries per page of results",
+                           "schema" => %{"type" => "integer"}
+                         }
+                       },
+                       "description" => "A paginated list of user entities"
+                     },
+                     "UserResponse" => %{
+                       "content" => %{
+                         "application/json" => %{
+                           "examples" => %{
+                             "response" => %{"value" => %{"id" => "1"}}
+                           },
+                           "schema" => %{
+                             "$ref" => "#/components/schemas/User"
+                           }
+                         }
+                       },
+                       "headers" => %{
+                         "limited" => %{
+                           "description" => "Have you been rate limited",
+                           "schema" => %{"type" => "boolean"}
+                         }
+                       },
+                       "description" => "A single user entity response"
+                     }
+                   },
+                   "schemas" => %{
+                     "Comment" => %{
+                       "description" => "A comment record",
+                       "properties" => %{
+                         "id" => %{
+                           "format" => "uuid",
+                           "type" => "string",
+                           "description" => "The comment id"
+                         },
+                         "text" => %{
+                           "type" => "string"
+                         }
+                       },
+                       "type" => "object"
+                     },
+                     "NotFound" => %{
+                       "description" => "Not found response",
+                       "properties" => %{
+                         "message" => %{
+                           "type" => "string"
+                         }
+                       },
+                       "type" => "object"
+                     },
+                     "Parent" => %{
+                       "properties" => %{"child" => %{"$ref" => "#/components/schemas/User"}},
+                       "type" => "object"
+                     },
+                     "User" => %{
+                       "type" => "object",
+                       "description" => "A user record",
+                       "required" => ["id", "email"],
+                       "properties" => %{
+                         "id" => %{
+                           "type" => "string",
+                           "format" => "uuid",
+                           "description" => "The id of the user"
+                         },
+                         "email" => %{
+                           "type" => "string",
+                           "description" => "The email of the user"
+                         },
+                         "comment" => %{
+                           "$ref" => "#/components/schemas/Comment"
+                         },
+                         "comments" => %{
+                           "type" => "array",
+                           "items" => %{
+                             "$ref" => "#/components/schemas/Comment"
+                           }
+                         },
+                         "comments_of_many_types" => %{
+                           "type" => "array",
+                           "description" => "List of text or comment",
+                           "items" => %{
+                             "oneOf" => [
+                               %{
+                                 "type" => "string"
+                               },
+                               %{
+                                 "$ref" => "#/components/schemas/Comment"
+                               }
+                             ]
+                           }
+                         },
+                         "multi" => %{
+                           "oneOf" => [
+                             %{
+                               "type" => "string"
+                             },
+                             %{"$ref" => "#/components/schemas/NotFound"}
+                           ]
+                         },
+                         "parent" => %{
+                           "$ref" => "#/components/schemas/Parent"
+                         },
+                         "private" => %{
+                           "type" => "boolean"
+                         },
+                         "archived" => %{
+                           "type" => "boolean"
+                         },
+                         "active" => %{
+                           "type" => "boolean"
+                         }
+                       }
+                     }
+                   },
+                   "securitySchemes" => %{
+                     "JWTAuth" => %{
+                       "type" => "http",
+                       "scheme" => "bearer"
+                     },
+                     "TokenAuth" => %{"type" => "oauth2"},
+                     "OAuth" => %{
+                       "type" => "oauth2",
+                       "flows" => %{
+                         "authorizationCode" => %{
+                           "authorizationUrl" => "https://applications.frame.io/oauth2/authorize",
+                           "tokenUrl" => "https://applications.frame.io/oauth2/token",
+                           "scopes" => [
+                             "user.read",
+                             "account.read",
+                             "account.write"
+                           ]
+                         }
+                       }
+                     }
+                   }
                  },
-                 update: %{type: :boolean}
-               },
-               responses: %{
-                 200 => %{type: :ref, ref: UserResponse},
-                 201 => %{type: :ref, ref: PaginatedUsersResponse},
-                 404 => %{type: :ref, ref: ErrorResponse}
-               },
-               tags: ["foo", "bar"],
-               verb: :get
-             }
-
-      assert result |> Enum.at(1) == %Route{
-               desc: "",
-               auth: %{JWTAuth: []},
-               headers: %{
-                 "X-Request-Id" => %{type: :string}
-               },
-               path: "/api/demo/:id",
-               verb: :post
-             }
-    end
-
-    test "It filters out routes that match the config" do
-      num_routes =
-        ConfigWithFilters
-        |> Config.new()
-        |> Rolodex.generate_routes()
-        |> length()
-
-      assert num_routes == 5
-    end
-  end
-
-  describe "#generate_refs/1" do
-    test "Generates a map of unique schemas from route header, body, query, path, and responses" do
-      routes = [
-        %Route{
-          headers: %{"X-Request-Id" => %{type: :uuid}},
-          body: %{type: :ref, ref: UserRequestBody},
-          responses: %{
-            200 => %{type: :ref, ref: UserResponse}
-          }
-        },
-        %Route{
-          headers: %{type: :ref, ref: PaginationHeaders},
-          body: %{type: :ref, ref: Parent},
-          responses: %{
-            200 => %{type: :ref, ref: UserResponse}
-          }
-        }
-      ]
-
-      %{responses: responses, request_bodies: request_bodies, schemas: schemas, headers: headers} =
-        Rolodex.generate_refs(routes)
-
-      assert Map.keys(responses) == [UserResponse]
-      assert Map.keys(request_bodies) == [UserRequestBody]
-      assert Map.keys(schemas) == [Comment, NotFound, Parent, User]
-      assert Map.keys(headers) == [PaginationHeaders, RateLimitHeaders]
-    end
-
-    test "Ignores data that contains no Rolodex.Schema references" do
-      routes = [
-        %Route{
-          headers: %{"X-Request-Id" => %{type: :uuid}},
-          responses: %{
-            200 => %{type: :ref, ref: UserResponse},
-            201 => :ok,
-            203 => "moved permanently",
-            123 => %{"hello" => "world"},
-            404 => %{type: :ref, ref: NestedDemo}
-          }
-        }
-      ]
-
-      %{responses: responses, request_bodies: request_bodies, schemas: schemas, headers: headers} =
-        Rolodex.generate_refs(routes)
-
-      assert Map.keys(request_bodies) == []
-      assert Map.keys(headers) == [RateLimitHeaders]
-      assert Map.keys(responses) == [UserResponse]
-
-      assert Map.keys(schemas) == [
-               Comment,
-               FirstNested,
-               NestedDemo,
-               NotFound,
-               Parent,
-               SecondNested,
-               User
-             ]
+                 "info" => %{"description" => nil, "title" => nil, "version" => nil},
+                 "openapi" => "3.0.0",
+                 "servers" => [%{"url" => "https://api.example.com"}],
+                 "paths" => %{
+                   "/api/demo" => %{
+                     "get" => %{
+                       "operationId" => "",
+                       "security" => [
+                         %{"JWTAuth" => []},
+                         %{"OAuth" => ["user.read"]},
+                         %{"TokenAuth" => ["user.read"]}
+                       ],
+                       "parameters" => [
+                         %{
+                           "in" => "header",
+                           "name" => "per-page",
+                           "required" => true,
+                           "description" => "Total entries per page of results",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         %{
+                           "in" => "header",
+                           "name" => "total",
+                           "description" => "Total entries to be retrieved",
+                           "schema" => %{"type" => "integer"}
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "account_id",
+                           "schema" => %{"format" => "uuid", "type" => "string"}
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "id",
+                           "schema" => %{
+                             "default" => 2,
+                             "maximum" => 10,
+                             "minimum" => 0,
+                             "type" => "string"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "update",
+                           "schema" => %{
+                             "type" => "boolean"
+                           }
+                         }
+                       ],
+                       "requestBody" => %{
+                         "$ref" => "#/components/requestBodies/UserRequestBody"
+                       },
+                       "responses" => %{
+                         "200" => %{
+                           "$ref" => "#/components/responses/UserResponse"
+                         },
+                         "201" => %{
+                           "$ref" => "#/components/responses/PaginatedUsersResponse"
+                         },
+                         "404" => %{
+                           "$ref" => "#/components/responses/ErrorResponse"
+                         }
+                       },
+                       "summary" => "It's a test!",
+                       "tags" => ["foo", "bar"]
+                     }
+                   },
+                   "/api/demo/{id}" => %{
+                     "post" => %{
+                       "operationId" => "",
+                       "security" => [%{"JWTAuth" => []}],
+                       "parameters" => [
+                         %{
+                           "in" => "header",
+                           "name" => "X-Request-Id",
+                           "schema" => %{
+                             "type" => "string"
+                           }
+                         }
+                       ],
+                       "responses" => %{},
+                       "summary" => "",
+                       "tags" => []
+                     },
+                     "put" => %{
+                       "operationId" => "",
+                       "security" => [],
+                       "parameters" => [
+                         %{
+                           "in" => "header",
+                           "name" => "X-Request-Id",
+                           "required" => true,
+                           "schema" => %{"format" => "uuid", "type" => "string"}
+                         }
+                       ],
+                       "requestBody" => %{
+                         "content" => %{
+                           "application/json" => %{
+                             "schema" => %{
+                               "type" => "object",
+                               "properties" => %{
+                                 "id" => %{
+                                   "type" => "string",
+                                   "format" => "uuid"
+                                 }
+                               }
+                             }
+                           }
+                         }
+                       },
+                       "responses" => %{
+                         "200" => %{
+                           "content" => %{
+                             "application/json" => %{
+                               "schema" => %{
+                                 "type" => "object",
+                                 "properties" => %{
+                                   "id" => %{
+                                     "type" => "string",
+                                     "format" => "uuid"
+                                   }
+                                 }
+                               }
+                             }
+                           }
+                         }
+                       },
+                       "summary" => "",
+                       "tags" => []
+                     }
+                   },
+                   "/api/multi" => %{
+                     "get" => %{
+                       "operationId" => "",
+                       "parameters" => [],
+                       "responses" => %{
+                         "200" => %{"$ref" => "#/components/responses/UserResponse"},
+                         "201" => %{"$ref" => "#/components/responses/MultiResponse"},
+                         "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
+                       },
+                       "security" => [%{"JWTAuth" => []}],
+                       "summary" => "It's an action used for multiple routes",
+                       "tags" => []
+                     }
+                   },
+                   "/api/nested/{nested_id}/multi" => %{
+                     "get" => %{
+                       "operationId" => "",
+                       "parameters" => [
+                         %{
+                           "in" => "path",
+                           "name" => "nested_id",
+                           "required" => true,
+                           "schema" => %{"format" => "uuid", "type" => "string"}
+                         }
+                       ],
+                       "responses" => %{
+                         "200" => %{"$ref" => "#/components/responses/UserResponse"},
+                         "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
+                       },
+                       "security" => [%{"JWTAuth" => []}],
+                       "summary" => "It's an action used for multiple routes",
+                       "tags" => []
+                     }
+                   }
+                 }
+               }
+      end)
     end
   end
 end


### PR DESCRIPTION
Rolodex can now serialize and write docs to multiple targets for a
single Phoenix router. This is helpful for cases where you want
more than one documentation source for a single API (e.g. public and
private API docs).

To accomplish this goal, we're introducing the concept of "render groups".
A render group is a combination of: (optional) filters, a processor, a
writer, and writer options. Together, they encapsulate Rolodex's render
logic: serialization and writing. You can specify as many render groups as
you'd like in your Rolodex config module to generate as many documentation
forms of your API!