### PR TITLE
Field formatting updates

### DIFF
--- a/lib/mix/tasks/rolodex.gen.docs.ex
+++ b/lib/mix/tasks/rolodex.gen.docs.ex
@@ -20,7 +20,9 @@ defmodule Mix.Tasks.Rolodex.Gen.Docs do
       {:error, err}, acc -> [err | acc]
     end)
     |> case do
-      [] -> IO.puts("Done!")
+      [] ->
+        IO.puts("Done!")
+
       errs ->
         IO.puts("Rolodex failed to compile some docs with the following errors:")
         Enum.each(errs, &IO.inspect(&1))

--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -50,7 +50,7 @@ defmodule Rolodex.Config do
   - `locale` (default: `"en"`) - Locale key to use when processing descriptions
   - `pipelines` (default: `%{}`) - Map of pipeline configs. Used to set default
   parameter values for all routes in a pipeline. See `Rolodex.PipelineConfig`.
-  - `render_groups` (default: `%Rolodex.RenderGroupConfig{}`) - List of render
+  - `render_groups` (default: `Rolodex.RenderGroupConfig`) - List of render
   groups.
   - `server_urls` (default: []) - List of base url(s) for your API paths
 

--- a/lib/rolodex/content_utils.ex
+++ b/lib/rolodex/content_utils.ex
@@ -89,6 +89,16 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  def set_field(attr, identifier, list_items, _opts) when is_list(list_items) do
+    quote do
+      Module.put_attribute(
+        __MODULE__,
+        unquote(attr),
+        {unquote(identifier), [type: :list, of: unquote(list_items)]}
+      )
+    end
+  end
+
   def set_field(attr, identifier, type, opts) do
     quote do
       Module.put_attribute(

--- a/lib/rolodex/field.ex
+++ b/lib/rolodex/field.ex
@@ -26,7 +26,7 @@ defmodule Rolodex.Field do
 
   ## Examples
 
-  ### Parsing primitive data types (e.g. `string`)
+  ### Parsing primitive data types (e.g. `integer`)
 
   Valid options for a primitive are:
 
@@ -39,12 +39,36 @@ defmodule Rolodex.Field do
   - `required`
 
       # Creating a simple field with a primitive type
-      iex> Rolodex.Field.new(:string)
-      %{type: :string}
+      iex> Rolodex.Field.new(:integer)
+      %{type: :integer}
 
       # With additional options
-      iex> Rolodex.Field.new(type: :string, desc: "My string", enum: ["foo", "bar"])
-      %{type: :string, desc: "My string", enum: ["foo", "bar"]}
+      iex> Rolodex.Field.new(type: :integer, desc: "My count", enum: [1, 2])
+      %{type: :integer, desc: "My count", enum: [1, 2]}
+
+  ### OpenAPI string formats
+
+  When serializing docs for OpenAPI (i.e. Swagger), the following primitive field
+  types will be converted into string formats:
+
+  - `date`
+  - `datetime`
+  - `date-time`
+  - `password`
+  - `byte`
+  - `binary`
+  - `uuid`
+  - `email`
+  - `uri`
+
+  For example:
+
+      # The following field
+      iex> Rolodex.Field.new(:date)
+      %{type: :date}
+
+      # Will be serialized like the following for OpenAPI docs
+      %{type: :string, format: :date}
 
   ### Parsing collections: objects and lists
 

--- a/lib/rolodex/processors/open_api.ex
+++ b/lib/rolodex/processors/open_api.ex
@@ -2,14 +2,25 @@ defmodule Rolodex.Processors.OpenAPI do
   @behaviour Rolodex.Processor
   @open_api_version "3.0.0"
 
-  @schema_metadata_keys [
-    :default,
-    :enum,
-    :format,
-    :maximum,
-    :minimum,
-    :type
-  ]
+  @schema_metadata_keys ~w(
+    default
+    enum
+    format
+    maximum
+    minimum
+    type
+  )a
+
+  @valid_string_formats ~w(
+    date
+    date-time
+    password
+    byte
+    binary
+    uuid
+    email
+    uri
+  )a
 
   alias Rolodex.{Config, Field, Headers, Route}
 
@@ -259,9 +270,16 @@ defmodule Rolodex.Processors.OpenAPI do
     }
   end
 
-  defp process_schema_field(%{type: :uuid} = field) do
+  defp process_schema_field(%{type: type} = field) when type in @valid_string_formats do
     field
-    |> Map.merge(%{type: :string, format: :uuid})
+    |> set_formatted_string_field(type)
+    |> process_schema_field()
+  end
+
+  # Also support datetime as a single word b/c the dash is weird especially in an atom
+  defp process_schema_field(%{type: :datetime} = field) do
+    field
+    |> set_formatted_string_field(:"date-time")
     |> process_schema_field()
   end
 
@@ -296,6 +314,12 @@ defmodule Rolodex.Processors.OpenAPI do
   end
 
   defp set_param_description(param), do: param
+
+  defp set_formatted_string_field(field, format) do
+    field
+    |> Map.put(:type, :string)
+    |> Map.put(:format, format)
+  end
 
   defp ref_path(mod) do
     case Field.get_ref_type(mod) do

--- a/lib/rolodex/schema.ex
+++ b/lib/rolodex/schema.ex
@@ -76,6 +76,8 @@ defmodule Rolodex.Schema do
   one argument is the field `identifier`. This can be used to fetch the field
   metadata later.
 
+  See `Rolodex.Field` for more information about valid field metadata.
+
   Accepts
   - `identifier` - field name
   - `type` - either an atom or another Rolodex.Schema module
@@ -98,6 +100,10 @@ defmodule Rolodex.Schema do
 
           # A field that is an array of items of one-or-more types
           field :multi, :list, of: [:string, OtherSchema]
+
+          # You can use a shorthand to define a list field, the below is identical
+          # to the above
+          field :multi, [:string, OtherSchema]
 
           # A field that is one of the possible provided types
           field :any, :one_of, of: [:string, OtherSchema]

--- a/test/rolodex/processors/open_api_test.exs
+++ b/test/rolodex/processors/open_api_test.exs
@@ -187,6 +187,12 @@ defmodule Rolodex.Processors.OpenAPITest do
                            "$ref" => "#/components/schemas/Comment"
                          }
                        },
+                       "short_comments" => %{
+                        "type" => "array",
+                        "items" => %{
+                          "$ref" => "#/components/schemas/Comment"
+                        }
+                      },
                        "comments_of_many_types" => %{
                          "type" => "array",
                          "description" => "List of text or comment",
@@ -433,6 +439,119 @@ defmodule Rolodex.Processors.OpenAPITest do
                }
              }
     end
+
+    test "It processes fields that should become formatted strings" do
+      routes = [
+        %Route{
+          id: "foo",
+          path: "/foo",
+          verb: :get,
+          desc: "GET /foo",
+          query_params: %{
+            id: %{type: :uuid},
+            email: %{type: :email},
+            url: %{type: :uri},
+            date: %{type: :date},
+            date_and_time: %{type: :datetime},
+            other_date_and_time: %{type: :"date-time"},
+            pass: %{type: :password},
+            chunk: %{type: :byte},
+            chunks: %{type: :binary}
+          },
+          responses: %{200 => %{type: :ref, ref: UserResponse}}
+        }
+      ]
+
+      assert OpenAPI.process_routes(routes, Config.new(BasicConfig)) == %{
+               "/foo" => %{
+                 get: %{
+                   operationId: "foo",
+                   summary: "GET /foo",
+                   security: [],
+                   tags: [],
+                   parameters: [
+                     %{
+                       in: :query,
+                       name: :chunk,
+                       schema: %{
+                         type: :string,
+                         format: :byte
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :chunks,
+                       schema: %{
+                         type: :string,
+                         format: :binary
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :date,
+                       schema: %{
+                         type: :string,
+                         format: :date
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :date_and_time,
+                       schema: %{
+                         type: :string,
+                         format: :"date-time"
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :email,
+                       schema: %{
+                         type: :string,
+                         format: :email
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :id,
+                       schema: %{
+                         type: :string,
+                         format: :uuid
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :other_date_and_time,
+                       schema: %{
+                         type: :string,
+                         format: :"date-time"
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :pass,
+                       schema: %{
+                         type: :string,
+                         format: :password
+                       }
+                     },
+                     %{
+                       in: :query,
+                       name: :url,
+                       schema: %{
+                         type: :string,
+                         format: :uri
+                       }
+                     }
+                   ],
+                   responses: %{
+                     200 => %{
+                       "$ref" => "#/components/responses/UserResponse"
+                     }
+                   }
+                 }
+               }
+             }
+    end
   end
 
   describe "#process_refs/1" do
@@ -509,6 +628,12 @@ defmodule Rolodex.Processors.OpenAPITest do
                          "$ref" => "#/components/schemas/Comment"
                        }
                      },
+                     short_comments: %{
+                      type: :array,
+                      items: %{
+                        "$ref" => "#/components/schemas/Comment"
+                      }
+                    },
                      comments_of_many_types: %{
                        type: :array,
                        description: "List of text or comment",

--- a/test/rolodex/schema_test.exs
+++ b/test/rolodex/schema_test.exs
@@ -23,6 +23,7 @@ defmodule Rolodex.SchemaTest do
                comment: %{type: :ref, ref: Comment},
                parent: %{type: :ref, ref: Parent},
                comments: %{type: :list, of: [%{type: :ref, ref: Comment}]},
+               short_comments: %{type: :list, of: [%{type: :ref, ref: Comment}]},
                comments_of_many_types: %{
                  desc: "List of text or comment",
                  type: :list,
@@ -59,6 +60,10 @@ defmodule Rolodex.SchemaTest do
                    type: :list,
                    of: [%{type: :ref, ref: Comment}]
                  },
+                 short_comments: %{
+                  type: :list,
+                  of: [%{type: :ref, ref: Comment}]
+                },
                  comments_of_many_types: %{
                    type: :list,
                    desc: "List of text or comment",

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -262,6 +262,12 @@ defmodule RolodexTest do
                              "$ref" => "#/components/schemas/Comment"
                            }
                          },
+                         "short_comments" => %{
+                          "type" => "array",
+                          "items" => %{
+                            "$ref" => "#/components/schemas/Comment"
+                          }
+                        },
                          "comments_of_many_types" => %{
                            "type" => "array",
                            "description" => "List of text or comment",
@@ -668,6 +674,12 @@ defmodule RolodexTest do
                              "$ref" => "#/components/schemas/Comment"
                            }
                          },
+                         "short_comments" => %{
+                          "type" => "array",
+                          "items" => %{
+                            "$ref" => "#/components/schemas/Comment"
+                          }
+                        },
                          "comments_of_many_types" => %{
                            "type" => "array",
                            "description" => "List of text or comment",

--- a/test/support/mocks/schemas.ex
+++ b/test/support/mocks/schemas.ex
@@ -20,6 +20,9 @@ defmodule Rolodex.Mocks.User do
     # List of one type
     field(:comments, :list, of: [Rolodex.Mocks.Comment])
 
+    # Can use the list shorthand
+    field :short_comments, [Rolodex.Mocks.Comment]
+
     # List of multiple types
     field(:comments_of_many_types, :list,
       of: [:string, Rolodex.Mocks.Comment],


### PR DESCRIPTION
1. Add support for more OpenAPI string formats. When we encounter a
   schema or paremeter field like `type: <format>` where the format
   is a valid OpenAPI string format, the docs output will become
   `type: "string", format: <format>".

2. Support list field shorthand for schema fields (we already do this
   for schemas used in responses and request bodies).