### PR TITLE
Rename Swagger processor to OpenAPI

### DIFF
--- a/lib/rolodex.ex
+++ b/lib/rolodex.ex
@@ -28,7 +28,7 @@ defmodule Rolodex do
   annotations on your API route action functions for the Rolodex parser to handle
   - **Generic serialization** - The `Rolodex.Processor` behaviour encapsulates
   the basic steps needed to serialize API metadata into documentation. Rolodex
-  ships with a valid Swagger JSON processor (see: `Rolodex.Processors.Swagger`)
+  ships with a valid OpenAPI (Swagger) JSON processor (see: `Rolodex.Processors.OpenAPI`)
   - **Generic writing** - The `Rolodex.Writer` behaviour encapsulates the basic
   steps needed to write out formatted docs. Rolodex ships with a file writer (
   see: `Rolodex.Writers.FileWriter`)

--- a/lib/rolodex/config.ex
+++ b/lib/rolodex/config.ex
@@ -215,7 +215,7 @@ defmodule Rolodex.RenderGroupConfig do
   out routes from your documentation. Filters are invoked in
   `Rolodex.Route.matches_filter?/2`. If the match returns true, the route will be
   filtered out of the docs result for this render group.
-  - `processor` (default: `Rolodex.Processors.Swagger`) - Module implementing
+  - `processor` (default: `Rolodex.Processors.OpenAPI`) - Module implementing
   the `Rolodex.Processor` behaviour
   - `writer` (default: `Rolodex.Writers.FileWriter`) - Module implementing the
   `Rolodex.Writer` behaviour to be used to write out the docs
@@ -224,7 +224,7 @@ defmodule Rolodex.RenderGroupConfig do
   """
 
   defstruct filters: :none,
-            processor: Rolodex.Processors.Swagger,
+            processor: Rolodex.Processors.OpenAPI,
             writer: Rolodex.Writers.FileWriter,
             writer_opts: [file_name: "api.json"]
 

--- a/lib/rolodex/processors/open_api.ex
+++ b/lib/rolodex/processors/open_api.ex
@@ -1,4 +1,4 @@
-defmodule Rolodex.Processors.Swagger do
+defmodule Rolodex.Processors.OpenAPI do
   @behaviour Rolodex.Processor
   @open_api_version "3.0.0"
 

--- a/test/rolodex/processors/open_api_test.exs
+++ b/test/rolodex/processors/open_api_test.exs
@@ -1,4 +1,4 @@
-defmodule Rolodex.Processors.SwaggerTest do
+defmodule Rolodex.Processors.OpenAPITest do
   use ExUnit.Case
 
   alias Rolodex.{
@@ -10,7 +10,7 @@ defmodule Rolodex.Processors.SwaggerTest do
     Headers
   }
 
-  alias Rolodex.Processors.Swagger
+  alias Rolodex.Processors.OpenAPI
 
   alias Rolodex.Mocks.{
     ErrorResponse,
@@ -94,7 +94,7 @@ defmodule Rolodex.Processors.SwaggerTest do
         }
       ]
 
-      result = Swagger.process(config, routes, refs) |> Jason.decode!()
+      result = OpenAPI.process(config, routes, refs) |> Jason.decode!()
 
       assert result == %{
                "openapi" => "3.0.0",
@@ -253,7 +253,7 @@ defmodule Rolodex.Processors.SwaggerTest do
     test "It returns a map of top-level metadata" do
       config = Config.new(FullConfig)
 
-      headers = Swagger.process_headers(config)
+      headers = OpenAPI.process_headers(config)
 
       assert headers == %{
                openapi: "3.0.0",
@@ -301,7 +301,7 @@ defmodule Rolodex.Processors.SwaggerTest do
         }
       ]
 
-      processed = Swagger.process_routes(routes, Config.new(BasicConfig))
+      processed = OpenAPI.process_routes(routes, Config.new(BasicConfig))
 
       assert processed == %{
                "/foo" => %{
@@ -390,7 +390,7 @@ defmodule Rolodex.Processors.SwaggerTest do
         }
       ]
 
-      assert Swagger.process_routes(routes, Config.new(BasicConfig)) == %{
+      assert OpenAPI.process_routes(routes, Config.new(BasicConfig)) == %{
                "/foo" => %{
                  get: %{
                    operationId: "foo",
@@ -452,7 +452,7 @@ defmodule Rolodex.Processors.SwaggerTest do
         }
       }
 
-      assert Swagger.process_refs(refs, Config.new(FullConfig)) == %{
+      assert OpenAPI.process_refs(refs, Config.new(FullConfig)) == %{
                requestBodies: %{
                  "UserRequestBody" => %{
                    content: %{


### PR DESCRIPTION
The JSON result this processor outputs is compliant to the OpenAPI 3.0
spec, which is not restrictive to the Swagger platform. I think the
naming of the processor should reflect this fact.