### PR TITLE
[PLATFORM-614] Schema partials

### DIFF
--- a/test/rolodex/processors/open_api_test.exs
+++ b/test/rolodex/processors/open_api_test.exs
@@ -188,11 +188,11 @@ defmodule Rolodex.Processors.OpenAPITest do
                          }
                        },
                        "short_comments" => %{
-                        "type" => "array",
-                        "items" => %{
-                          "$ref" => "#/components/schemas/Comment"
-                        }
-                      },
+                         "type" => "array",
+                         "items" => %{
+                           "$ref" => "#/components/schemas/Comment"
+                         }
+                       },
                        "comments_of_many_types" => %{
                          "type" => "array",
                          "description" => "List of text or comment",
@@ -629,11 +629,11 @@ defmodule Rolodex.Processors.OpenAPITest do
                        }
                      },
                      short_comments: %{
-                      type: :array,
-                      items: %{
-                        "$ref" => "#/components/schemas/Comment"
-                      }
-                    },
+                       type: :array,
+                       items: %{
+                         "$ref" => "#/components/schemas/Comment"
+                       }
+                     },
                      comments_of_many_types: %{
                        type: :array,
                        description: "List of text or comment",

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -263,11 +263,11 @@ defmodule RolodexTest do
                            }
                          },
                          "short_comments" => %{
-                          "type" => "array",
-                          "items" => %{
-                            "$ref" => "#/components/schemas/Comment"
-                          }
-                        },
+                           "type" => "array",
+                           "items" => %{
+                             "$ref" => "#/components/schemas/Comment"
+                           }
+                         },
                          "comments_of_many_types" => %{
                            "type" => "array",
                            "description" => "List of text or comment",
@@ -675,11 +675,11 @@ defmodule RolodexTest do
                            }
                          },
                          "short_comments" => %{
-                          "type" => "array",
-                          "items" => %{
-                            "$ref" => "#/components/schemas/Comment"
-                          }
-                        },
+                           "type" => "array",
+                           "items" => %{
+                             "$ref" => "#/components/schemas/Comment"
+                           }
+                         },
                          "comments_of_many_types" => %{
                            "type" => "array",
                            "description" => "List of text or comment",

--- a/test/support/mocks/schemas.ex
+++ b/test/support/mocks/schemas.ex
@@ -21,7 +21,7 @@ defmodule Rolodex.Mocks.User do
     field(:comments, :list, of: [Rolodex.Mocks.Comment])
 
     # Can use the list shorthand
-    field :short_comments, [Rolodex.Mocks.Comment]
+    field(:short_comments, [Rolodex.Mocks.Comment])
 
     # List of multiple types
     field(:comments_of_many_types, :list,
@@ -83,5 +83,16 @@ defmodule Rolodex.Mocks.SecondNested do
 
   schema "SecondNested" do
     field(:id, :uuid)
+  end
+end
+
+defmodule Rolodex.Mocks.WithPartials do
+  use Rolodex.Schema
+
+  schema "WithPartials" do
+    field(:created_at, :datetime)
+
+    partial(Rolodex.Mocks.Comment)
+    partial(mentions: [:uuid])
   end
 end


### PR DESCRIPTION
New addition to the schema DSL. With partials, you can merge
parameters from another schema into a new schema definition. This
is especially useful for parameters shared across multiple schemas,
such as pagination metadata.