### PR TITLE
[PLATFORM-615] Inline schema macros for requests and responses

### DIFF
--- a/lib/rolodex/dsl.ex
+++ b/lib/rolodex/dsl.ex
@@ -1,20 +1,38 @@
-defmodule Rolodex.ContentUtils do
+defmodule Rolodex.DSL do
   @moduledoc false
 
-  alias Rolodex.Field
+  alias Rolodex.{Field, Schema}
 
-  def def_content_body(type, name, do: block) do
+  # Sets the various shared module attributes used in DSL macros to collect
+  # metadata definitions
+  defmacro __using__(_) do
     quote do
+      # Used in various macro helpers
+      alias Rolodex.Field
+
+      # Used to collect content body (requests, responses) metadata
       Module.register_attribute(__MODULE__, :content_types, accumulate: true)
       Module.register_attribute(__MODULE__, :current_content_type, accumulate: false)
       Module.register_attribute(__MODULE__, :body_description, accumulate: false)
       Module.register_attribute(__MODULE__, :headers, accumulate: true)
+      Module.register_attribute(__MODULE__, :examples, accumulate: true)
 
+      # Used to collect schema definition metadata
+      Module.register_attribute(__MODULE__, :fields, accumulate: true)
+      Module.register_attribute(__MODULE__, :partials, accumulate: true)
+
+      # Set defaults for non-accumulators
+      @current_content_type nil
       @body_description nil
+    end
+  end
 
+  ### Macro Helpers ###
+
+  # Opens up a shared content body definition (i.e. request body or response)
+  def def_content_body(type, name, do: block) do
+    quote do
       unquote(block)
-
-      Module.delete_attribute(__MODULE__, :current_content_type)
 
       def unquote(type)(:name), do: unquote(name)
       def unquote(type)(:desc), do: @body_description
@@ -23,12 +41,14 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Sets the description of a content body
   def set_desc(str) do
     quote do
       @body_description unquote(str)
     end
   end
 
+  # Sets the headers for a response
   def set_headers({:__aliases__, _, _} = mod) do
     quote do
       @headers Field.new(unquote(mod))
@@ -41,10 +61,9 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Opens up a content body chunk for a specific content-type (e.g. "application/json")
   def def_content_type_shape(type, key, do: block) do
     quote do
-      Module.register_attribute(__MODULE__, :examples, accumulate: true)
-
       @content_types unquote(key)
       @current_content_type unquote(key)
 
@@ -56,6 +75,7 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Sets an example for the current content-type
   def set_example(type, name, example_body) do
     quote do
       @examples unquote(name)
@@ -65,6 +85,30 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Opens up a schema definition. This helper is used both to define shared
+  # schema modules (Rolodex.Schema) and to define inline schemas via the macro
+  # DSL within content bodies
+  def set_schema(type, do: block) do
+    quote do
+      unquote(block)
+
+      # @current_content_type will be `nil` when using this helper in Rolodex.Schema
+      def unquote(type)({@current_content_type, :schema}) do
+        fields = Map.new(@fields, fn {id, opts} -> {id, Field.new(opts)} end)
+        partials = @partials |> Enum.reverse()
+
+        Field.new(
+          type: :object,
+          properties: Rolodex.DSL.schema_fields_with_partials(fields, partials)
+        )
+      end
+
+      Module.delete_attribute(__MODULE__, :fields)
+      Module.delete_attribute(__MODULE__, :partials)
+    end
+  end
+
+  # Sets the schema for the current content-type
   def set_schema(type, mods) when is_list(mods) do
     quote do
       def unquote(type)({@current_content_type, :schema}) do
@@ -73,6 +117,7 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Sets the schema for the current content-type
   def set_schema(type, mod) do
     quote do
       def unquote(type)({@current_content_type, :schema}) do
@@ -81,6 +126,7 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Sets the schema for the current content-type
   def set_schema(type, collection_type, of: mods) do
     quote do
       def unquote(type)({@current_content_type, :schema}) do
@@ -89,6 +135,7 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Sets a field within a schema block or headers block
   def set_field(attr, identifier, list_items, _opts) when is_list(list_items) do
     quote do
       Module.put_attribute(
@@ -99,6 +146,7 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Sets a field within a schema block or headers block
   def set_field(attr, identifier, type, opts) do
     quote do
       Module.put_attribute(
@@ -109,6 +157,16 @@ defmodule Rolodex.ContentUtils do
     end
   end
 
+  # Sets a partial within a schema block
+  def set_partial(mod) do
+    quote do
+      @partials Field.new(unquote(mod))
+    end
+  end
+
+  ### Function Helpers ###
+
+  # Check the given module against the given module type
   def is_module_of_type?(mod, type) when is_atom(mod) do
     try do
       mod.__info__(:functions) |> Keyword.has_key?(type)
@@ -119,7 +177,8 @@ defmodule Rolodex.ContentUtils do
 
   def is_module_of_type?(_), do: false
 
-  def to_map(fun) do
+  # Serializes content body metadata
+  def to_content_body_map(fun) do
     %{
       desc: fun.(:desc),
       headers: fun.(:headers),
@@ -144,15 +203,16 @@ defmodule Rolodex.ContentUtils do
     |> Map.new(&{&1, fun.({content_type, :examples, &1})})
   end
 
-  def get_refs(fun) do
+  # Collects nested refs in a content body
+  def get_refs_in_content_body(fun) do
     fun
-    |> to_map()
+    |> to_content_body_map()
     |> Map.take([:headers, :content])
     |> collect_refs(MapSet.new())
     |> Enum.to_list()
   end
 
-  def collect_refs(data, refs) do
+  defp collect_refs(data, refs) do
     refs
     |> set_headers_ref(data)
     |> set_content_refs(data)
@@ -174,4 +234,15 @@ defmodule Rolodex.ContentUtils do
       |> MapSet.union(acc)
     end)
   end
+
+  # Merges partials into schema fields
+  def schema_fields_with_partials(fields, []), do: fields
+
+  def schema_fields_with_partials(fields, partials),
+    do: Enum.reduce(partials, fields, &merge_partial/2)
+
+  defp merge_partial(%{type: :ref, ref: ref}, fields),
+    do: ref |> Schema.to_map() |> merge_partial(fields)
+
+  defp merge_partial(%{properties: props}, fields), do: Map.merge(fields, props)
 end

--- a/lib/rolodex/headers.ex
+++ b/lib/rolodex/headers.ex
@@ -15,10 +15,11 @@ defmodule Rolodex.Headers do
   - `to_map/1` - serializes the headers module into a map
   """
 
-  alias Rolodex.{ContentUtils, Field}
+  alias Rolodex.{DSL, Field}
 
   defmacro __using__(_) do
     quote do
+      use Rolodex.DSL
       import Rolodex.Headers, only: :macros
     end
   end
@@ -44,8 +45,6 @@ defmodule Rolodex.Headers do
   """
   defmacro headers(name, do: block) do
     quote do
-      Module.register_attribute(__MODULE__, :headers, accumulate: true)
-
       unquote(block)
 
       def __headers__(:name), do: unquote(name)
@@ -64,7 +63,7 @@ defmodule Rolodex.Headers do
   valid options.
   """
   defmacro field(identifier, type, opts \\ []) do
-    ContentUtils.set_field(:headers, identifier, type, opts)
+    DSL.set_field(:headers, identifier, type, opts)
   end
 
   @doc """
@@ -88,17 +87,7 @@ defmodule Rolodex.Headers do
       false
   """
   @spec is_headers_module?(any()) :: boolean()
-  def is_headers_module?(item)
-
-  def is_headers_module?(module) when is_atom(module) do
-    try do
-      module.__info__(:functions) |> Keyword.has_key?(:__headers__)
-    rescue
-      _ -> false
-    end
-  end
-
-  def is_headers_module?(_), do: false
+  def is_headers_module?(mod), do: DSL.is_module_of_type?(mod, :__headers__)
 
   @doc """
   Serializes the `Rolodex.Headers` metadata into a formatted map

--- a/lib/rolodex/request_body.ex
+++ b/lib/rolodex/request_body.ex
@@ -19,10 +19,11 @@ defmodule Rolodex.RequestBody do
   `Rolodex.Schema` refs within
   """
 
-  alias Rolodex.ContentUtils
+  alias Rolodex.DSL
 
   defmacro __using__(_opts) do
     quote do
+      use Rolodex.DSL
       import Rolodex.RequestBody, only: :macros
     end
   end
@@ -59,15 +60,13 @@ defmodule Rolodex.RequestBody do
       end
   """
   defmacro request_body(name, opts) do
-    ContentUtils.def_content_body(:__request_body__, name, opts)
+    DSL.def_content_body(:__request_body__, name, opts)
   end
 
   @doc """
   Sets a description for the request body
   """
-  defmacro desc(str) do
-    ContentUtils.set_desc(str)
-  end
+  defmacro desc(str), do: DSL.set_desc(str)
 
   @doc """
   Defines a request body shape for the given content type key
@@ -77,7 +76,7 @@ defmodule Rolodex.RequestBody do
   - `block` - metadata about the request body shape for this content type
   """
   defmacro content(key, opts) do
-    ContentUtils.def_content_type_shape(:__request_body__, key, opts)
+    DSL.def_content_type_shape(:__request_body__, key, opts)
   end
 
   @doc """
@@ -89,23 +88,32 @@ defmodule Rolodex.RequestBody do
   - `body` - a map, which is the example data
   """
   defmacro example(name, example_body) do
-    ContentUtils.set_example(:__request_body__, name, example_body)
+    DSL.set_example(:__request_body__, name, example_body)
   end
 
   @doc """
-  Sets a schema for the current request body content type. Data passed into to
-  the schema/1 macro will be parsed by `Rolodex.Field.new/1`.
+  Sets a schema for the current request body content type. There are three ways
+  you can define a schema for a content-type chunk:
+
+  1. You can pass in an alias for a reusable schema defined via `Rolodex.Schema`
+  2. You can define a schema inline via the same macro syntax used in `Rolodex.Schema`
+  3. You can define a schema inline via a bare map, which will be parsed with `Rolodex.Field`
 
   ## Examples
 
-      # Request body is a list, where each item is a MySchema
+      # Via a reusable schema alias
       content "application/json" do
-        schema [MySchema]
+        schema MySchema
       end
 
-      # Request body is a MySchema
+      # Can define a schema inline via the schema + field + partial macros
       content "application/json" do
-        content MySchema
+        schema do
+          field :id, :uuid
+          field :name, :string, desc: "The name"
+
+          partial PaginationParams
+        end
       end
 
       # Can provide a bare map, which will be parsed via `Rolodex.Field`
@@ -119,9 +127,7 @@ defmodule Rolodex.RequestBody do
         }
       end
   """
-  defmacro schema(mod) do
-    ContentUtils.set_schema(:__request_body__, mod)
-  end
+  defmacro schema(mod), do: DSL.set_schema(:__request_body__, mod)
 
   @doc """
   Sets a schema of a collection type.
@@ -139,8 +145,86 @@ defmodule Rolodex.RequestBody do
       end
   """
   defmacro schema(collection_type, opts) do
-    ContentUtils.set_schema(:__request_body__, collection_type, opts)
+    DSL.set_schema(:__request_body__, collection_type, opts)
   end
+
+  @doc """
+  Adds a new field to the schema when defining a schema inline via macros. See
+  `Rolodex.Field` for more information about valid field metadata.
+
+  Accepts
+  - `identifier` - field name
+  - `type` - either an atom or another Rolodex.Schema module
+  - `opts` - a keyword list of options, looks for `desc` and `of` (for array types)
+
+  ## Example
+
+      defmodule MyRequestBody do
+        use Rolodex.RequestBody
+
+        request_body "MyRequestBody" do
+          content "application/json" do
+            schema do
+              # Atomic field with no description
+              field :id, :uuid
+
+              # Atomic field with a description
+              field :name, :string, desc: "The object's name"
+
+              # A field that refers to another, nested object
+              field :other, OtherSchema
+
+              # A field that is an array of items of one-or-more types
+              field :multi, :list, of: [:string, OtherSchema]
+
+              # You can use a shorthand to define a list field, the below is identical
+              # to the above
+              field :multi, [:string, OtherSchema]
+
+              # A field that is one of the possible provided types
+              field :any, :one_of, of: [:string, OtherSchema]
+            end
+          end
+        end
+      end
+  """
+  defmacro field(identifier, type, opts \\ []) do
+    DSL.set_field(:fields, identifier, type, opts)
+  end
+
+  @doc """
+  Adds a new partial to the schema when defining a schema inline via macros. A
+  partial is another schema that will be serialized and merged into the top-level
+  properties map for the current schema. Partials are useful for shared parameters
+  used across multiple schemas. Bare keyword lists and maps that are parseable
+  by `Rolodex.Field` are also supported.
+
+  ## Example
+
+      defmodule PaginationParams do
+        use Rolodex.Schema
+
+        schema "PaginationParams" do
+          field :page, :integer
+          field :page_size, :integer
+          field :total_pages, :integer
+        end
+      end
+
+      defmodule MyRequestBody do
+        use Rolodex.RequestBody
+
+        request_body "MyRequestBody" do
+          content "application/json" do
+            schema do
+              field :id, :uuid
+              partial PaginationParams
+            end
+          end
+        end
+      end
+  """
+  defmacro partial(mod), do: DSL.set_partial(mod)
 
   @doc """
   Determines if an arbitrary item is a module that has defined a reusable
@@ -166,7 +250,7 @@ defmodule Rolodex.RequestBody do
       false
   """
   @spec is_request_body_module?(any()) :: boolean()
-  def is_request_body_module?(mod), do: ContentUtils.is_module_of_type?(mod, :__request_body__)
+  def is_request_body_module?(mod), do: DSL.is_module_of_type?(mod, :__request_body__)
 
   @doc """
   Serializes the `Rolodex.RequestBody` metadata into a formatted map.
@@ -230,12 +314,12 @@ defmodule Rolodex.RequestBody do
       }
   """
   @spec to_map(module()) :: map()
-  def to_map(mod), do: ContentUtils.to_map(&mod.__request_body__/1)
+  def to_map(mod), do: DSL.to_content_body_map(&mod.__request_body__/1)
 
   @doc """
   Traverses a serialized Request Body and collects any nested references to any
   Schemas within. See `Rolodex.Field.get_refs/1` for more info.
   """
   @spec get_refs(module()) :: [module()]
-  def get_refs(mod), do: ContentUtils.get_refs(&mod.__request_body__/1)
+  def get_refs(mod), do: DSL.get_refs_in_content_body(&mod.__request_body__/1)
 end

--- a/test/rolodex/request_body_test.exs
+++ b/test/rolodex/request_body_test.exs
@@ -11,7 +11,8 @@ defmodule Rolodex.RequestBodyTest do
     MultiRequestBody,
     User,
     Comment,
-    Parent
+    Parent,
+    InlineMacroSchemaRequest
   }
 
   doctest RequestBody
@@ -72,6 +73,18 @@ defmodule Rolodex.RequestBodyTest do
                    type: :list,
                    of: [%{type: :ref, ref: User}]
                  }
+               }
+             }
+    end
+
+    test "It handles an inline macro" do
+      assert InlineMacroSchemaRequest.__request_body__({"application/json", :schema}) == %{
+               type: :object,
+               properties: %{
+                 created_at: %{type: :datetime},
+                 id: %{type: :uuid, desc: "The comment id"},
+                 text: %{type: :string},
+                 mentions: %{type: :list, of: [%{type: :uuid}]}
                }
              }
     end

--- a/test/rolodex/response_test.exs
+++ b/test/rolodex/response_test.exs
@@ -13,7 +13,8 @@ defmodule Rolodex.ResponseTest do
     User,
     Comment,
     Parent,
-    PaginationHeaders
+    PaginationHeaders,
+    InlineMacroSchemaResponse
   }
 
   doctest Response
@@ -105,6 +106,18 @@ defmodule Rolodex.ResponseTest do
                    type: :list,
                    of: [%{type: :ref, ref: User}]
                  }
+               }
+             }
+    end
+
+    test "It handles an inline macro" do
+      assert InlineMacroSchemaResponse.__response__({"application/json", :schema}) == %{
+               type: :object,
+               properties: %{
+                 created_at: %{type: :datetime},
+                 id: %{type: :uuid, desc: "The comment id"},
+                 text: %{type: :string},
+                 mentions: %{type: :list, of: [%{type: :uuid}]}
                }
              }
     end

--- a/test/rolodex/schema_test.exs
+++ b/test/rolodex/schema_test.exs
@@ -17,45 +17,47 @@ defmodule Rolodex.SchemaTest do
     test "It generates schema metadata" do
       assert User.__schema__(:name) == "User"
       assert User.__schema__(:desc) == "A user record"
-      assert User.__schema__(:partials) == []
 
-      assert User.__schema__(:fields) == %{
-               id: %{type: :uuid, desc: "The id of the user", required: true},
-               email: %{type: :string, desc: "The email of the user", required: true},
-               comment: %{type: :ref, ref: Comment},
-               parent: %{type: :ref, ref: Parent},
-               comments: %{type: :list, of: [%{type: :ref, ref: Comment}]},
-               short_comments: %{type: :list, of: [%{type: :ref, ref: Comment}]},
-               comments_of_many_types: %{
-                 desc: "List of text or comment",
-                 type: :list,
-                 of: [
-                   %{type: :string},
-                   %{type: :ref, ref: Comment}
-                 ]
-               },
-               multi: %{
-                 type: :one_of,
-                 of: [
-                   %{type: :string},
-                   %{type: :ref, ref: NotFound}
-                 ]
-               },
-               private: %{type: :boolean},
-               archived: %{type: :boolean},
-               active: %{type: :boolean}
+      assert User.__schema__({nil, :schema}) == %{
+               type: :object,
+               properties: %{
+                 id: %{type: :uuid, desc: "The id of the user", required: true},
+                 email: %{type: :string, desc: "The email of the user", required: true},
+                 comment: %{type: :ref, ref: Comment},
+                 parent: %{type: :ref, ref: Parent},
+                 comments: %{type: :list, of: [%{type: :ref, ref: Comment}]},
+                 short_comments: %{type: :list, of: [%{type: :ref, ref: Comment}]},
+                 comments_of_many_types: %{
+                   desc: "List of text or comment",
+                   type: :list,
+                   of: [
+                     %{type: :string},
+                     %{type: :ref, ref: Comment}
+                   ]
+                 },
+                 multi: %{
+                   type: :one_of,
+                   of: [
+                     %{type: :string},
+                     %{type: :ref, ref: NotFound}
+                   ]
+                 },
+                 private: %{type: :boolean},
+                 archived: %{type: :boolean},
+                 active: %{type: :boolean}
+               }
              }
     end
   end
 
   describe "#partial/1 macro" do
     test "It will collect schema refs, plain keyword lists, or plain maps for merging" do
-      assert WithPartials.__schema__(:partials) |> length() == 2
-      assert WithPartials.__schema__(:partials) |> Enum.at(0) == %{type: :ref, ref: Comment}
-
-      assert WithPartials.__schema__(:partials) |> Enum.at(1) == %{
+      assert WithPartials.__schema__({nil, :schema}) == %{
                type: :object,
                properties: %{
+                 created_at: %{type: :datetime},
+                 id: %{type: :uuid, desc: "The comment id"},
+                 text: %{type: :string},
                  mentions: %{type: :list, of: [%{type: :uuid}]}
                }
              }

--- a/test/support/mocks/request_bodies.ex
+++ b/test/support/mocks/request_bodies.ex
@@ -72,3 +72,20 @@ defmodule Rolodex.Mocks.MultiRequestBody do
     end
   end
 end
+
+defmodule Rolodex.Mocks.InlineMacroSchemaRequest do
+  use Rolodex.RequestBody
+
+  alias Rolodex.Mocks.Comment
+
+  request_body "InlineMacroSchemaRequest" do
+    content "application/json" do
+      schema do
+        field(:created_at, :datetime)
+
+        partial(Comment)
+        partial(mentions: [:uuid])
+      end
+    end
+  end
+end

--- a/test/support/mocks/responses.ex
+++ b/test/support/mocks/responses.ex
@@ -105,3 +105,20 @@ defmodule Rolodex.Mocks.MultiResponse do
     end
   end
 end
+
+defmodule Rolodex.Mocks.InlineMacroSchemaResponse do
+  use Rolodex.Response
+
+  alias Rolodex.Mocks.Comment
+
+  response "InlineMacroSchemaResponse" do
+    content "application/json" do
+      schema do
+        field(:created_at, :datetime)
+
+        partial(Comment)
+        partial(mentions: [:uuid])
+      end
+    end
+  end
+end


### PR DESCRIPTION
~NOTE: Blocked by #61~

This refactor adds support for defining request body and response
schemas via an inline macro syntax. This will allow users to leverage
partial schemas in their content bodies, without needing to define
standalone schemas via Rolodex.Schema.