### PR TITLE
[PLATFORM-616] Schemas for query and path params

### DIFF
--- a/lib/rolodex.ex
+++ b/lib/rolodex.ex
@@ -72,7 +72,11 @@ defmodule Rolodex do
           desc "A request body"
 
           content "application/json" do
-            schema MySchema
+            schema do
+              field :id, :integer
+              field :name, :string
+            end
+
             example :request, %{id: "123", name: "Ada Lovelace"}
           end
         end
@@ -197,10 +201,7 @@ defmodule Rolodex do
                 }
               },
               "requestBody" => %{
-                "type" => "object",
-                "properties" => %{
-                  "id" => %{"type" => "string", "format" => "uuid"}
-                }
+                "$ref" => "#/components/requestBodies/MyRequestBody"
               },
               "tags" => ["foo", "bar"]
             }
@@ -213,7 +214,11 @@ defmodule Rolodex do
               "content" => %{
                 "application/json" => %{
                   "schema" => %{
-                    "$ref" => "#/components/schemas/MySchema"
+                    "type" => "object",
+                    "properties" => %{
+                      "id" => %{"type" => "string", "format" => "uuid"},
+                      "name" => %{"type" => "string", "description" => "The name"}
+                    }
                   },
                   "examples" => %{
                     "request" => %{"id" => "123", "name" => "Ada Lovelace"}

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -275,6 +275,48 @@ defmodule Rolodex.RouteTest do
              }
     end
 
+    test "It serializes query and path param schema refs", %{config: config} do
+      phoenix_route = %Router.Route{
+        plug: TestController,
+        opts: :params_via_schema,
+        path: "/v2/test",
+        pipe_through: [],
+        verb: :get
+      }
+
+      %Route{query_params: query, path_params: path} = Route.new(phoenix_route, config)
+
+      assert query == %{
+               account_id: %{type: :uuid},
+               team_id: %{
+                 type: :integer,
+                 maximum: 10,
+                 minimum: 0,
+                 required: true,
+                 default: 2
+               },
+               created_at: %{type: :datetime},
+               id: %{type: :uuid, desc: "The comment id"},
+               text: %{type: :string},
+               mentions: %{type: :list, of: [%{type: :uuid}]}
+             }
+
+      assert path == %{
+               account_id: %{type: :uuid},
+               team_id: %{
+                 type: :integer,
+                 maximum: 10,
+                 minimum: 0,
+                 required: true,
+                 default: 2
+               },
+               created_at: %{type: :datetime},
+               id: %{type: :uuid, desc: "The comment id"},
+               text: %{type: :string},
+               mentions: %{type: :list, of: [%{type: :uuid}]}
+             }
+    end
+
     test "It handles an undocumented route" do
       phoenix_route = %Router.Route{
         plug: TestController,

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -499,6 +499,127 @@ defmodule RolodexTest do
                        "summary" => "It's an action used for multiple routes",
                        "tags" => []
                      }
+                   },
+                   "/api/partials" => %{
+                     "get" => %{
+                       "parameters" => [
+                         %{
+                           "in" => "path",
+                           "name" => "account_id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "created_at",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "date-time"
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "id",
+                           "description" => "The comment id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "mentions",
+                           "schema" => %{
+                             "type" => "array",
+                             "items" => %{
+                               "type" => "string",
+                               "format" => "uuid"
+                             }
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "team_id",
+                           "required" => true,
+                           "schema" => %{
+                             "type" => "integer",
+                             "maximum" => 10,
+                             "minimum" => 0,
+                             "default" => 2
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "text",
+                           "schema" => %{
+                             "type" => "string"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "account_id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "created_at",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "date-time"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "id",
+                           "description" => "The comment id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "mentions",
+                           "schema" => %{
+                             "type" => "array",
+                             "items" => %{
+                               "type" => "string",
+                               "format" => "uuid"
+                             }
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "team_id",
+                           "required" => true,
+                           "schema" => %{
+                             "type" => "integer",
+                             "maximum" => 10,
+                             "minimum" => 0,
+                             "default" => 2
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "text",
+                           "schema" => %{
+                             "type" => "string"
+                           }
+                         }
+                       ],
+                       "responses" => %{
+                         "200" => %{"$ref" => "#/components/responses/UserResponse"}
+                       },
+                       "operationId" => "",
+                       "security" => [],
+                       "summary" => "",
+                       "tags" => []
+                     }
                    }
                  }
                }
@@ -901,6 +1022,127 @@ defmodule RolodexTest do
                        },
                        "security" => [%{"JWTAuth" => []}],
                        "summary" => "It's an action used for multiple routes",
+                       "tags" => []
+                     }
+                   },
+                   "/api/partials" => %{
+                     "get" => %{
+                       "parameters" => [
+                         %{
+                           "in" => "path",
+                           "name" => "account_id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "created_at",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "date-time"
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "id",
+                           "description" => "The comment id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "mentions",
+                           "schema" => %{
+                             "type" => "array",
+                             "items" => %{
+                               "type" => "string",
+                               "format" => "uuid"
+                             }
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "team_id",
+                           "required" => true,
+                           "schema" => %{
+                             "type" => "integer",
+                             "maximum" => 10,
+                             "minimum" => 0,
+                             "default" => 2
+                           }
+                         },
+                         %{
+                           "in" => "path",
+                           "name" => "text",
+                           "schema" => %{
+                             "type" => "string"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "account_id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "created_at",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "date-time"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "id",
+                           "description" => "The comment id",
+                           "schema" => %{
+                             "type" => "string",
+                             "format" => "uuid"
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "mentions",
+                           "schema" => %{
+                             "type" => "array",
+                             "items" => %{
+                               "type" => "string",
+                               "format" => "uuid"
+                             }
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "team_id",
+                           "required" => true,
+                           "schema" => %{
+                             "type" => "integer",
+                             "maximum" => 10,
+                             "minimum" => 0,
+                             "default" => 2
+                           }
+                         },
+                         %{
+                           "in" => "query",
+                           "name" => "text",
+                           "schema" => %{
+                             "type" => "string"
+                           }
+                         }
+                       ],
+                       "responses" => %{
+                         "200" => %{"$ref" => "#/components/responses/UserResponse"}
+                       },
+                       "operationId" => "",
+                       "security" => [],
+                       "summary" => "",
                        "tags" => []
                      }
                    }

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -5,7 +5,8 @@ defmodule Rolodex.Mocks.TestController do
     MultiResponse,
     PaginatedUsersResponse,
     PaginationHeaders,
-    ErrorResponse
+    ErrorResponse,
+    ParamsSchema
   }
 
   @doc [
@@ -78,6 +79,15 @@ defmodule Rolodex.Mocks.TestController do
     }
   ]
   def with_bare_maps(_, _), do: nil
+
+  @doc [
+    query_params: ParamsSchema,
+    path_params: ParamsSchema,
+    responses: %{
+      200 => UserResponse
+    }
+  ]
+  def params_via_schema(_, _), do: nil
 
   def undocumented(_, _), do: nil
 end

--- a/test/support/mocks/routers.ex
+++ b/test/support/mocks/routers.ex
@@ -11,6 +11,9 @@ defmodule Rolodex.Mocks.TestRouter do
     get("/multi", TestController, :multi)
     get("/nested/:nested_id/multi", TestController, :multi)
 
+    # This action function uses schemas for query and path params plus partials
+    get("/partials", TestController, :params_via_schema)
+
     # This route action does not exist
     put("/demo/missing/:id", TestController, :missing_action)
   end

--- a/test/support/mocks/schemas.ex
+++ b/test/support/mocks/schemas.ex
@@ -96,3 +96,22 @@ defmodule Rolodex.Mocks.WithPartials do
     partial(mentions: [:uuid])
   end
 end
+
+defmodule Rolodex.Mocks.ParamsSchema do
+  use Rolodex.Schema
+
+  alias Rolodex.Mocks.WithPartials
+
+  schema "ParamsSchema" do
+    field(:account_id, :uuid)
+
+    field(:team_id, :integer,
+      maximum: 10,
+      minimum: 0,
+      required: true,
+      default: 2
+    )
+
+    partial(WithPartials)
+  end
+end


### PR DESCRIPTION
This refactors our support to using schemas in the `query_params`
and `path_params` doc annotation items. Like with headers, we will
serialize these schemas in full in the Route parser. No changes are
needed to the way we serialize params in the OpenAPI processor, b/c
the data passed in will always be a map. I've chosen this approach,
rather than supporting serializing path and query params via component
references because of the slightly different shape of parameter descriptions.