### PR TITLE
Split multi route actions based on HTTP method

### DIFF
--- a/lib/rolodex/utils.ex
+++ b/lib/rolodex/utils.ex
@@ -37,4 +37,26 @@ defmodule Rolodex.Utils do
   end
 
   defp uncapitalize(<<char, rest::binary>>), do: String.downcase(<<char>>) <> rest
+
+  @doc """
+  Similar to Ruby's `with_indifferent_access`, this function performs an indifferent
+  key lookup on a map or keyword list. Indifference means that the keys :foo and
+  "foo" are considered identical. We only convert from atom -> string to avoid
+  the unsafe `String.to_atom/1` function.
+  """
+  @spec indifferent_find(map() | keyword(), atom() | binary()) :: any()
+  def indifferent_find(data, key) when is_atom(key),
+    do: indifferent_find(data, Atom.to_string(key))
+
+  def indifferent_find(data, key) do
+    data
+    |> Enum.find(fn
+      {k, _} when is_atom(k) -> Atom.to_string(k) == key
+      {k, _} -> k == key
+    end)
+    |> case do
+      {_, result} -> result
+      _ -> nil
+    end
+  end
 end

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -219,6 +219,35 @@ defmodule Rolodex.RouteTest do
              }
     end
 
+    test "It uses the Phoenix route verb to pull out docs for a multi-headed controller action",
+        %{
+          config: config
+        } do
+    result =
+      %Router.Route{
+        plug: TestController,
+        opts: :multi,
+        path: "/api/nested/:nested_id/multi",
+        verb: :post
+      }
+      |> Route.new(config)
+
+    assert result == %Route{
+              auth: %{JWTAuth: []},
+              desc: "It's an action used for multiple routes",
+              path_params: %{
+                nested_id: %{type: :uuid, required: true}
+              },
+              responses: %{
+                200 => %{type: :ref, ref: UserResponse},
+                404 => %{type: :ref, ref: ErrorResponse}
+              },
+              path: "/api/nested/:nested_id/multi",
+              verb: :post,
+              pipe_through: nil
+            }
+    end
+
     test "It returns nil if no path matches the Phoenix route path for a multi-headed controller action",
          %{
            config: config

--- a/test/rolodex/utils_test.exs
+++ b/test/rolodex/utils_test.exs
@@ -1,0 +1,16 @@
+defmodule Rolodex.UtilsTest do
+  use ExUnit.Case
+
+  alias Rolodex.Utils
+
+  describe "#indifferent_find/2" do
+    test "It will lookup indifferently" do
+      data = %{} |> Map.put(:foo, :bar) |> Map.put("bar", :baz)
+
+      assert Utils.indifferent_find(data, :foo) == :bar
+      assert Utils.indifferent_find(data, "foo") == :bar
+      assert Utils.indifferent_find(data, :bar) == :baz
+      assert Utils.indifferent_find(data, "bar") == :baz
+    end
+  end
+end

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -66,6 +66,30 @@ defmodule Rolodex.Mocks.TestController do
   def multi(_, _), do: nil
 
   @doc [
+    multi: true,
+    get: [
+      auth: :JWTAuth,
+      responses: %{
+        200 => UserResponse,
+        201 => MultiResponse,
+        404 => ErrorResponse
+      }
+    ],
+    post: [
+      auth: :JWTAuth,
+      path_params: [
+        nested_id: [type: :uuid, required: true]
+      ],
+      responses: %{
+        200 => UserResponse,
+        404 => ErrorResponse
+      }
+    ]
+  ]
+  @doc "It's an action used for the same path with multiple HTTP actions"
+  def verb_multi(_, _), do: nil
+
+  @doc [
     auth: :JWTAuth,
     headers: %{"X-Request-Id" => :string}
   ]


### PR DESCRIPTION
We currently support documenting controller actions that are used
multiple times across distinct API paths. We also want to support
the case where a controller action is used multiple times across
the same path but different HTTP methods.