### PR TITLE
Release v0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 swag-*.tar
 
+.elixir_ls

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ deps in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rolodex, "~> 0.8.0"}
+    {:rolodex, "~> 0.9.0"}
   ]
 end
 ```

--- a/lib/rolodex/dsl.ex
+++ b/lib/rolodex/dsl.ex
@@ -166,18 +166,23 @@ defmodule Rolodex.DSL do
 
   ### Function Helpers ###
 
-  # Check the given module against the given module type
+  @doc """
+  Check the given module against the given module type
+  """
+  @spec is_module_of_type?(module(), atom()) :: boolean()
   def is_module_of_type?(mod, type) when is_atom(mod) do
-    try do
-      mod.__info__(:functions) |> Keyword.has_key?(type)
-    rescue
+    case Code.ensure_compiled(mod) do
+      {:module, loaded} -> function_exported?(loaded, type, 1)
       _ -> false
     end
   end
 
-  def is_module_of_type?(_), do: false
+  def is_module_of_type?(_, _), do: false
 
+  # @doc """
   # Serializes content body metadata
+  # """
+  # @spec to_content_body_map(function()) :: map()
   def to_content_body_map(fun) do
     %{
       desc: fun.(:desc),

--- a/lib/rolodex/router.ex
+++ b/lib/rolodex/router.ex
@@ -1,0 +1,205 @@
+defmodule Rolodex.Router do
+  @moduledoc """
+  Macros for defining API routes that Rolodex should document. Functions for
+  serializing these routes into fully formed docs metadata.
+
+  A Rolodex Router is the entry point when Rolodex is compiling your docs. You
+  provide the router with two things:
+
+    1) A Phoenix Router
+    2) A list of API paths (HTTP action + full URI path)
+
+  Rolodex then looks up the controller action function associated with each API
+  path, collects the doc annotations for each, and serializes it all to your docs
+  output of choice.
+
+  ## Example
+
+      defmodule MyRolodexRouter do
+        use Rolodex.Router
+
+        alias MyWebApp.PhoenixRouter
+
+        router PhoenixRouter do
+          # Can use macros that pair with HTTP actions, just like in Phoenix
+          get "/api/users"
+          post "/api/users"
+          put "/api/users/:id"
+          patch "/api/users/:id"
+          delete "/api/users/:id"
+          head "/api/users/:id"
+          options "/api/users/:id"
+
+          # Our can use the more verbose route/2 macro
+          route :get, "/api/users"
+
+          # Use routes/2 to define multiple routes that use the same path
+          routes [:put, :patch, :delete], "/api/users/:id"
+        end
+      end
+  """
+
+  alias Rolodex.Utils
+  alias Rolodex.Router.RouteInfo
+
+  defmacro __using__(_) do
+    quote do
+      import Rolodex.Router, only: :macros
+    end
+  end
+
+  @doc """
+  Opens up a definition for a Rolodex router. Used to define which routes Rolodex
+  should document.
+
+      router MyApp.MyPhoenixRouter do
+        get "/api/health"
+
+        get "/api/users"
+        post "/api/users"
+        put "/api/users/:id"
+      end
+  """
+  defmacro router(phoenix_router, do: block) do
+    quote do
+      Module.register_attribute(__MODULE__, :routes, accumulate: true)
+
+      unquote(block)
+
+      def __router__(:phoenix_router), do: unquote(phoenix_router)
+      def __router__(:routes), do: @routes
+    end
+  end
+
+  @doc """
+  Defines a set of routes with different HTTP action verbs at the same path to document
+
+      routes [:get, :put, :delete], "/api/entity/:id"
+  """
+  defmacro routes(verbs, path) when is_list(verbs) do
+    quote do
+      unquote(Enum.map(verbs, &set_route(&1, path)))
+    end
+  end
+
+  @doc """
+  Defines a route with the given HTTP action verb and path to document
+
+      route :get, "/api/entity/:id"
+  """
+  defmacro route(verb, path) when is_atom(verb), do: set_route(verb, path)
+
+  @doc """
+  Defines an HTTP GET route at the given path to document
+
+      get "/api/entity/:id"
+  """
+  defmacro get(path), do: set_route(:get, path)
+
+  @doc """
+  Defines an HTTP POST route at the given path to document
+
+      post "/api/entity"
+  """
+  defmacro post(path), do: set_route(:post, path)
+
+  @doc """
+  Defines an HTTP PUT route at the given path to document
+
+      put "/api/entity/:id"
+  """
+  defmacro put(path), do: set_route(:put, path)
+
+  @doc """
+  Defines an HTTP PATCH route at the given path to document
+
+      patch "/api/entity/:id"
+  """
+  defmacro patch(path), do: set_route(:patch, path)
+
+  @doc """
+  Defines an HTTP DELETE route at the given path to document
+
+      delete "/api/entity/:id"
+  """
+  defmacro delete(path), do: set_route(:delete, path)
+
+  @doc """
+  Defines an HTTP HEAD route at the given path to document
+
+      head "/api/entity/:id"
+  """
+  defmacro head(path), do: set_route(:head, path)
+
+  @doc """
+  Defines an HTTP OPTIONS route at the given path to document
+
+      options "/api/entity/:id"
+  """
+  defmacro options(path), do: set_route(:options, path)
+
+  defp set_route(verb, path) do
+    quote do
+      @routes {unquote(verb), unquote(path)}
+    end
+  end
+
+  @doc """
+  Collects all the routes defined in a `Rolodex.Router` into a list of fully
+  serialized `Rolodex.Route` structs.
+  """
+  @spec build_routes(module(), Rolodex.Config.t()) :: [Rolodex.Route.t()]
+  def build_routes(router_mod, config) do
+    phoenix_router = router_mod.__router__(:phoenix_router)
+
+    router_mod.__router__(:routes)
+    |> Enum.reduce([], fn {verb, path}, routes ->
+      # If Rolodex can't find a matching Phoenix route OR if the associated
+      # controller action has no doc annotation, `build_route/4` will return `nil`
+      # and we strip it from the results
+      case build_route(verb, path, phoenix_router, config) do
+        nil -> routes
+        route -> [route | routes]
+      end
+    end)
+  end
+
+  defp build_route(verb, path, phoenix_router, config) do
+    phoenix_router
+    |> build_route_info(verb, path)
+    |> with_doc_annotation()
+    |> Rolodex.Route.new(config)
+  end
+
+  # Backwards compatibility logic for fetching Phoenix route info:
+  #
+  #   1.4.0 ~ 1.4.7 — Lookup via private router tree
+  #   >= 1.4.7 — Use publicly supported `Phoenix.Router.route_info/4`
+  defp build_route_info(phoenix_router, verb, path) do
+    case function_exported?(Phoenix.Router, :route_info, 4) do
+      true ->
+        http_action_string = verb |> Atom.to_string() |> String.upcase()
+
+        phoenix_router
+        |> Phoenix.Router.route_info(http_action_string, path, "")
+        |> RouteInfo.from_route_info(verb)
+
+      false ->
+        phoenix_router.__routes__()
+        |> Enum.find(fn
+          %{verb: ^verb, path: ^path} -> true
+          _ -> false
+        end)
+        |> RouteInfo.from_router_tree()
+    end
+  end
+
+  defp with_doc_annotation(%RouteInfo{controller: controller, action: action} = info) do
+    case Utils.fetch_doc_annotation(controller, action) do
+      {:error, :not_found} -> nil
+      {:ok, desc, metadata} -> %{info | desc: desc, metadata: metadata}
+    end
+  end
+
+  defp with_doc_annotation(_), do: nil
+end

--- a/lib/rolodex/router/route_info.ex
+++ b/lib/rolodex/router/route_info.ex
@@ -1,0 +1,60 @@
+defmodule Rolodex.Router.RouteInfo do
+  @moduledoc false
+
+  import Rolodex.Utils, only: [to_struct: 2]
+
+  defstruct [
+    :action,
+    :controller,
+    :desc,
+    :metadata,
+    :path,
+    :pipe_through,
+    :verb
+  ]
+
+  @type t :: %__MODULE__{
+          action: atom(),
+          controller: module(),
+          desc: binary(),
+          metadata: map() | list() | nil,
+          path: binary(),
+          pipe_through: list(),
+          verb: atom()
+        }
+
+  def new(params), do: params |> Map.new() |> to_struct(__MODULE__)
+
+  def from_route_info(
+        %{plug: controller, plug_opts: action, route: path, pipe_through: pipe_through},
+        verb
+      ) do
+    %__MODULE__{
+      controller: controller,
+      action: action,
+      path: path,
+      verb: verb,
+      pipe_through: pipe_through
+    }
+  end
+
+  def from_route_info(_, _), do: nil
+
+  def from_router_tree(%{
+        plug: controller,
+        opts: action,
+        path: path,
+        verb: verb,
+        pipe_through: pipe_through
+      }) do
+    %__MODULE__{
+      controller: controller,
+      action: action,
+      path: path,
+      verb: verb,
+      pipe_through: pipe_through
+    }
+  end
+
+  def from_router_tree(_), do: nil
+end

--- a/lib/rolodex/utils.ex
+++ b/lib/rolodex/utils.ex
@@ -1,13 +1,14 @@
 defmodule Rolodex.Utils do
   @moduledoc false
 
-  # Pipeline friendly dynamic struct creator
+  @doc """
+  Pipeline friendly dynamic struct creator
+  """
   def to_struct(data, module), do: struct(module, data)
 
-  # Pipeline friendly helper to generate {:ok, result} tuples
-  def ok(data), do: {:ok, data}
-
-  # Recursively convert a keyword list into a map
+  @doc """
+  Recursively convert a keyword list into a map
+  """
   def to_map_deep(data, level \\ 0)
   def to_map_deep([], 0), do: %{}
 
@@ -20,7 +21,9 @@ defmodule Rolodex.Utils do
 
   def to_map_deep(data, _), do: data
 
-  # Recursively convert all keys in a map from snake_case to camelCase
+  @doc """
+  Recursively convert all keys in a map from snake_case to camelCase
+  """
   def camelize_map(data) when not is_map(data), do: data
 
   def camelize_map(data) do
@@ -57,6 +60,26 @@ defmodule Rolodex.Utils do
     |> case do
       {_, result} -> result
       _ -> nil
+    end
+  end
+
+  @doc """
+  Grabs the description and metadata map associated with the given function via
+  `@doc` annotations.
+  """
+  @spec fetch_doc_annotation(module(), atom()) :: {:ok, binary(), map()} | {:error, :not_found}
+  def fetch_doc_annotation(controller, action) do
+    controller
+    |> Code.fetch_docs()
+    |> Tuple.to_list()
+    |> Enum.at(-1)
+    |> Enum.find(fn
+      {{:function, ^action, _arity}, _, _, _, _} -> true
+      _ -> false
+    end)
+    |> case do
+      {_, _, _, desc, metadata} -> {:ok, desc, metadata}
+      _ -> {:error, :not_found}
     end
   end
 end

--- a/lib/rolodex/utils.ex
+++ b/lib/rolodex/utils.ex
@@ -37,4 +37,26 @@ defmodule Rolodex.Utils do
   end
 
   defp uncapitalize(<<char, rest::binary>>), do: String.downcase(<<char>>) <> rest
+
+  @doc """
+  Similar to Ruby's `with_indifferent_access`, this function performs an indifferent
+  key lookup on a map or keyword list. Indifference means that the keys :foo and
+  "foo" are considered identical. We only convert from atom -> string to avoid
+  the unsafe `String.to_atom/1` function.
+  """
+  @spec indifferent_find(map() | keyword(), atom() | binary()) :: any()
+  def indifferent_find(data, key) when is_atom(key),
+    do: indifferent_find(data, Atom.to_string(key))
+
+  def indifferent_find(data, key) do
+    data
+    |> Enum.find(fn
+      {k, _} when is_atom(k) -> Atom.to_string(k) == key
+      {k, _} -> k == key
+    end)
+    |> case do
+      {_, result} -> result
+      _ -> nil
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Rolodex.MixProject do
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       {:jason, "~> 1.1"},
-      {:phoenix, "~> 1.4.0"},
+      {:phoenix, ">= 1.4.0"},
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Rolodex.MixProject do
       app: :rolodex,
       name: "Rolodex",
       description: "Automated docs generation",
-      version: "0.8.1",
+      version: "0.9.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Rolodex.MixProject do
       app: :rolodex,
       name: "Rolodex",
       description: "Automated docs generation",
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/rolodex/config_test.exs
+++ b/test/rolodex/config_test.exs
@@ -2,6 +2,7 @@ defmodule Rolodex.ConfigTest do
   use ExUnit.Case
 
   alias Rolodex.{Config, PipelineConfig, RenderGroupConfig}
+  alias Rolodex.Mocks.TestRouter
 
   defmodule BasicConfig do
     use Rolodex.Config
@@ -10,8 +11,7 @@ defmodule Rolodex.ConfigTest do
       [
         description: "Hello world",
         title: "BasicConfig",
-        version: "0.0.1",
-        router: MyRouter
+        version: "0.0.1"
       ]
     end
   end
@@ -23,15 +23,14 @@ defmodule Rolodex.ConfigTest do
       [
         description: "Hello world",
         title: "BasicConfig",
-        version: "0.0.1",
-        router: MyRouter
+        version: "0.0.1"
       ]
     end
 
     def render_groups_spec() do
       [
-        [writer_opts: [file_name: "api-public.json"]],
-        [writer_opts: [file_name: "api-private.json"]]
+        [router: TestRouter, writer_opts: [file_name: "api-public.json"]],
+        [router: TestRouter, writer_opts: [file_name: "api-private.json"]]
       ]
     end
 
@@ -77,7 +76,6 @@ defmodule Rolodex.ConfigTest do
                pipelines: %{},
                title: "BasicConfig",
                version: "0.0.1",
-               router: MyRouter,
                render_groups: [%RenderGroupConfig{}]
              }
     end
@@ -112,10 +110,15 @@ defmodule Rolodex.ConfigTest do
                },
                title: "BasicConfig",
                version: "0.0.1",
-               router: MyRouter,
                render_groups: [
-                 %RenderGroupConfig{writer_opts: [file_name: "api-public.json"]},
-                 %RenderGroupConfig{writer_opts: [file_name: "api-private.json"]}
+                 %RenderGroupConfig{
+                   router: TestRouter,
+                   writer_opts: [file_name: "api-public.json"]
+                 },
+                 %RenderGroupConfig{
+                   router: TestRouter,
+                   writer_opts: [file_name: "api-private.json"]
+                 }
                ]
              }
     end

--- a/test/rolodex/route_test.exs
+++ b/test/rolodex/route_test.exs
@@ -219,6 +219,35 @@ defmodule Rolodex.RouteTest do
              }
     end
 
+    test "It uses the Phoenix route verb to pull out docs for a multi-headed controller action",
+        %{
+          config: config
+        } do
+    result =
+      %Router.Route{
+        plug: TestController,
+        opts: :multi,
+        path: "/api/nested/:nested_id/multi",
+        verb: :post
+      }
+      |> Route.new(config)
+
+    assert result == %Route{
+              auth: %{JWTAuth: []},
+              desc: "It's an action used for multiple routes",
+              path_params: %{
+                nested_id: %{type: :uuid, required: true}
+              },
+              responses: %{
+                200 => %{type: :ref, ref: UserResponse},
+                404 => %{type: :ref, ref: ErrorResponse}
+              },
+              path: "/api/nested/:nested_id/multi",
+              verb: :post,
+              pipe_through: nil
+            }
+    end
+
     test "It returns nil if no path matches the Phoenix route path for a multi-headed controller action",
          %{
            config: config

--- a/test/rolodex/router_test.exs
+++ b/test/rolodex/router_test.exs
@@ -1,0 +1,143 @@
+defmodule Rolodex.RouterTest do
+  use ExUnit.Case
+
+  alias Rolodex.{Config, Route, Router}
+
+  alias Rolodex.Mocks.{
+    TestPhoenixRouter,
+    TestRouter,
+    UserRequestBody,
+    UserResponse,
+    PaginatedUsersResponse,
+    ErrorResponse,
+    MultiResponse
+  }
+
+  defmodule(BasicConfig, do: use(Config))
+
+  describe "macros" do
+    test "It sets the expected private functions on the router module" do
+      assert TestRouter.__router__(:phoenix_router) == TestPhoenixRouter
+
+      assert TestRouter.__router__(:routes) == [
+               put: "/api/demo/missing/:id",
+               get: "/api/partials",
+               get: "/api/nested/:nested_id/multi",
+               get: "/api/multi",
+               delete: "/api/demo/:id",
+               put: "/api/demo/:id",
+               post: "/api/demo/:id",
+               get: "/api/demo"
+             ]
+    end
+  end
+
+  describe "#build_routes/2" do
+    test "It builds %Rolodex.Route{} structs from the router data" do
+      result = Router.build_routes(TestRouter, Config.new(BasicConfig))
+
+      assert result == [
+               %Route{
+                 auth: %{JWTAuth: [], OAuth: ["user.read"], TokenAuth: ["user.read"]},
+                 body: %{ref: UserRequestBody, type: :ref},
+                 desc: "It's a test!",
+                 headers: %{
+                   "per-page" => %{
+                     desc: "Total entries per page of results",
+                     required: true,
+                     type: :integer
+                   },
+                   "total" => %{desc: "Total entries to be retrieved", type: :integer}
+                 },
+                 id: "",
+                 metadata: %{public: true},
+                 path: "/api/demo",
+                 path_params: %{account_id: %{type: :uuid}},
+                 query_params: %{
+                   id: %{default: 2, maximum: 10, minimum: 0, required: false, type: :string},
+                   update: %{type: :boolean}
+                 },
+                 responses: %{
+                   200 => %{ref: UserResponse, type: :ref},
+                   201 => %{ref: PaginatedUsersResponse, type: :ref},
+                   404 => %{ref: ErrorResponse, type: :ref}
+                 },
+                 tags: ["foo", "bar"],
+                 verb: :get
+               },
+               %Route{
+                 auth: %{JWTAuth: []},
+                 headers: %{"X-Request-Id" => %{type: :string}},
+                 path: "/api/demo/:id",
+                 verb: :post
+               },
+               %Route{
+                 body: %{properties: %{id: %{type: :uuid}}, type: :object},
+                 headers: %{"X-Request-Id" => %{required: true, type: :uuid}},
+                 path: "/api/demo/:id",
+                 responses: %{200 => %{properties: %{id: %{type: :uuid}}, type: :object}},
+                 verb: :put
+               },
+               %Route{
+                 path: "/api/demo/:id",
+                 verb: :delete
+               },
+               %Route{
+                 auth: %{JWTAuth: []},
+                 desc: "It's an action used for multiple routes",
+                 path: "/api/multi",
+                 responses: %{
+                   200 => %{ref: UserResponse, type: :ref},
+                   201 => %{ref: MultiResponse, type: :ref},
+                   404 => %{ref: ErrorResponse, type: :ref}
+                 },
+                 verb: :get
+               },
+               %Route{
+                 auth: %{JWTAuth: []},
+                 desc: "It's an action used for multiple routes",
+                 path: "/api/nested/:nested_id/multi",
+                 path_params: %{nested_id: %{required: true, type: :uuid}},
+                 responses: %{
+                   200 => %{ref: UserResponse, type: :ref},
+                   404 => %{ref: ErrorResponse, type: :ref}
+                 },
+                 verb: :get
+               },
+               %Route{
+                 path: "/api/partials",
+                 path_params: %{
+                   account_id: %{type: :uuid},
+                   created_at: %{type: :datetime},
+                   id: %{desc: "The comment id", type: :uuid},
+                   mentions: %{of: [%{type: :uuid}], type: :list},
+                   team_id: %{
+                     default: 2,
+                     maximum: 10,
+                     minimum: 0,
+                     required: true,
+                     type: :integer
+                   },
+                   text: %{type: :string}
+                 },
+                 query_params: %{
+                   account_id: %{type: :uuid},
+                   created_at: %{type: :datetime},
+                   id: %{desc: "The comment id", type: :uuid},
+                   mentions: %{of: [%{type: :uuid}], type: :list},
+                   team_id: %{
+                     default: 2,
+                     maximum: 10,
+                     minimum: 0,
+                     required: true,
+                     type: :integer
+                   },
+                   text: %{type: :string}
+                 },
+                 responses: %{200 => %{ref: UserResponse, type: :ref}},
+                 verb: :get
+               }
+             ]
+    end
+  end
+end

--- a/test/rolodex/utils_test.exs
+++ b/test/rolodex/utils_test.exs
@@ -1,0 +1,16 @@
+defmodule Rolodex.UtilsTest do
+  use ExUnit.Case
+
+  alias Rolodex.Utils
+
+  describe "#indifferent_find/2" do
+    test "It will lookup indifferently" do
+      data = %{} |> Map.put(:foo, :bar) |> Map.put("bar", :baz)
+
+      assert Utils.indifferent_find(data, :foo) == :bar
+      assert Utils.indifferent_find(data, "foo") == :bar
+      assert Utils.indifferent_find(data, :bar) == :baz
+      assert Utils.indifferent_find(data, "bar") == :baz
+    end
+  end
+end

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -7,14 +7,11 @@ defmodule RolodexTest do
     use Rolodex.Config
 
     def spec() do
-      [
-        router: Rolodex.Mocks.TestRouter,
-        server_urls: ["https://api.example.com"]
-      ]
+      [server_urls: ["https://api.example.com"]]
     end
 
     def render_groups_spec() do
-      [[writer_opts: []]]
+      [[router: Rolodex.Mocks.TestRouter, writer_opts: []]]
     end
   end
 
@@ -22,17 +19,14 @@ defmodule RolodexTest do
     use Rolodex.Config
 
     def spec() do
-      [
-        router: Rolodex.Mocks.TestRouter,
-        server_urls: ["https://api.example.com"]
-      ]
+      [server_urls: ["https://api.example.com"]]
     end
 
     def render_groups_spec() do
       [
-        [writer: Rolodex.Writers.Mock],
+        [router: Rolodex.Mocks.TestRouter, writer: Rolodex.Writers.Mock],
         [
-          filters: [%{path: "/api/demo/:id", verb: :delete}],
+          router: Rolodex.Mocks.MiniTestRouter,
           writer: Rolodex.Writers.Mock
         ]
       ]
@@ -657,40 +651,6 @@ defmodule RolodexTest do
                        },
                        "description" => "An error response"
                      },
-                     "MultiResponse" => %{
-                       "description" => nil,
-                       "headers" => %{
-                         "total" => %{
-                           "description" => "Total entries to be retrieved",
-                           "schema" => %{"type" => "integer"}
-                         },
-                         "per-page" => %{
-                           "description" => "Total entries per page of results",
-                           "schema" => %{"type" => "integer"}
-                         },
-                         "limited" => %{
-                           "description" => "Have you been rate limited",
-                           "schema" => %{"type" => "boolean"}
-                         }
-                       },
-                       "content" => %{
-                         "application/json" => %{
-                           "examples" => %{},
-                           "schema" => %{
-                             "$ref" => "#/components/schemas/User"
-                           }
-                         },
-                         "application/lolsob" => %{
-                           "examples" => %{},
-                           "schema" => %{
-                             "type" => "array",
-                             "items" => %{
-                               "$ref" => "#/components/schemas/Comment"
-                             }
-                           }
-                         }
-                       }
-                     },
                      "PaginatedUsersResponse" => %{
                        "content" => %{
                          "application/json" => %{
@@ -925,225 +885,6 @@ defmodule RolodexTest do
                        },
                        "summary" => "It's a test!",
                        "tags" => ["foo", "bar"]
-                     }
-                   },
-                   "/api/demo/{id}" => %{
-                     "post" => %{
-                       "operationId" => "",
-                       "security" => [%{"JWTAuth" => []}],
-                       "parameters" => [
-                         %{
-                           "in" => "header",
-                           "name" => "X-Request-Id",
-                           "schema" => %{
-                             "type" => "string"
-                           }
-                         }
-                       ],
-                       "responses" => %{},
-                       "summary" => "",
-                       "tags" => []
-                     },
-                     "put" => %{
-                       "operationId" => "",
-                       "security" => [],
-                       "parameters" => [
-                         %{
-                           "in" => "header",
-                           "name" => "X-Request-Id",
-                           "required" => true,
-                           "schema" => %{"format" => "uuid", "type" => "string"}
-                         }
-                       ],
-                       "requestBody" => %{
-                         "content" => %{
-                           "application/json" => %{
-                             "schema" => %{
-                               "type" => "object",
-                               "properties" => %{
-                                 "id" => %{
-                                   "type" => "string",
-                                   "format" => "uuid"
-                                 }
-                               }
-                             }
-                           }
-                         }
-                       },
-                       "responses" => %{
-                         "200" => %{
-                           "content" => %{
-                             "application/json" => %{
-                               "schema" => %{
-                                 "type" => "object",
-                                 "properties" => %{
-                                   "id" => %{
-                                     "type" => "string",
-                                     "format" => "uuid"
-                                   }
-                                 }
-                               }
-                             }
-                           }
-                         }
-                       },
-                       "summary" => "",
-                       "tags" => []
-                     }
-                   },
-                   "/api/multi" => %{
-                     "get" => %{
-                       "operationId" => "",
-                       "parameters" => [],
-                       "responses" => %{
-                         "200" => %{"$ref" => "#/components/responses/UserResponse"},
-                         "201" => %{"$ref" => "#/components/responses/MultiResponse"},
-                         "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
-                       },
-                       "security" => [%{"JWTAuth" => []}],
-                       "summary" => "It's an action used for multiple routes",
-                       "tags" => []
-                     }
-                   },
-                   "/api/nested/{nested_id}/multi" => %{
-                     "get" => %{
-                       "operationId" => "",
-                       "parameters" => [
-                         %{
-                           "in" => "path",
-                           "name" => "nested_id",
-                           "required" => true,
-                           "schema" => %{"format" => "uuid", "type" => "string"}
-                         }
-                       ],
-                       "responses" => %{
-                         "200" => %{"$ref" => "#/components/responses/UserResponse"},
-                         "404" => %{"$ref" => "#/components/responses/ErrorResponse"}
-                       },
-                       "security" => [%{"JWTAuth" => []}],
-                       "summary" => "It's an action used for multiple routes",
-                       "tags" => []
-                     }
-                   },
-                   "/api/partials" => %{
-                     "get" => %{
-                       "parameters" => [
-                         %{
-                           "in" => "path",
-                           "name" => "account_id",
-                           "schema" => %{
-                             "type" => "string",
-                             "format" => "uuid"
-                           }
-                         },
-                         %{
-                           "in" => "path",
-                           "name" => "created_at",
-                           "schema" => %{
-                             "type" => "string",
-                             "format" => "date-time"
-                           }
-                         },
-                         %{
-                           "in" => "path",
-                           "name" => "id",
-                           "description" => "The comment id",
-                           "schema" => %{
-                             "type" => "string",
-                             "format" => "uuid"
-                           }
-                         },
-                         %{
-                           "in" => "path",
-                           "name" => "mentions",
-                           "schema" => %{
-                             "type" => "array",
-                             "items" => %{
-                               "type" => "string",
-                               "format" => "uuid"
-                             }
-                           }
-                         },
-                         %{
-                           "in" => "path",
-                           "name" => "team_id",
-                           "required" => true,
-                           "schema" => %{
-                             "type" => "integer",
-                             "maximum" => 10,
-                             "minimum" => 0,
-                             "default" => 2
-                           }
-                         },
-                         %{
-                           "in" => "path",
-                           "name" => "text",
-                           "schema" => %{
-                             "type" => "string"
-                           }
-                         },
-                         %{
-                           "in" => "query",
-                           "name" => "account_id",
-                           "schema" => %{
-                             "type" => "string",
-                             "format" => "uuid"
-                           }
-                         },
-                         %{
-                           "in" => "query",
-                           "name" => "created_at",
-                           "schema" => %{
-                             "type" => "string",
-                             "format" => "date-time"
-                           }
-                         },
-                         %{
-                           "in" => "query",
-                           "name" => "id",
-                           "description" => "The comment id",
-                           "schema" => %{
-                             "type" => "string",
-                             "format" => "uuid"
-                           }
-                         },
-                         %{
-                           "in" => "query",
-                           "name" => "mentions",
-                           "schema" => %{
-                             "type" => "array",
-                             "items" => %{
-                               "type" => "string",
-                               "format" => "uuid"
-                             }
-                           }
-                         },
-                         %{
-                           "in" => "query",
-                           "name" => "team_id",
-                           "required" => true,
-                           "schema" => %{
-                             "type" => "integer",
-                             "maximum" => 10,
-                             "minimum" => 0,
-                             "default" => 2
-                           }
-                         },
-                         %{
-                           "in" => "query",
-                           "name" => "text",
-                           "schema" => %{
-                             "type" => "string"
-                           }
-                         }
-                       ],
-                       "responses" => %{
-                         "200" => %{"$ref" => "#/components/responses/UserResponse"}
-                       },
-                       "operationId" => "",
-                       "security" => [],
-                       "summary" => "",
-                       "tags" => []
                      }
                    }
                  }

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -66,6 +66,30 @@ defmodule Rolodex.Mocks.TestController do
   def multi(_, _), do: nil
 
   @doc [
+    multi: true,
+    get: [
+      auth: :JWTAuth,
+      responses: %{
+        200 => UserResponse,
+        201 => MultiResponse,
+        404 => ErrorResponse
+      }
+    ],
+    post: [
+      auth: :JWTAuth,
+      path_params: [
+        nested_id: [type: :uuid, required: true]
+      ],
+      responses: %{
+        200 => UserResponse,
+        404 => ErrorResponse
+      }
+    ]
+  ]
+  @doc "It's an action used for the same path with multiple HTTP actions"
+  def verb_multi(_, _), do: nil
+
+  @doc [
     auth: :JWTAuth,
     headers: %{"X-Request-Id" => :string}
   ]

--- a/test/support/mocks/controllers.ex
+++ b/test/support/mocks/controllers.ex
@@ -1,4 +1,6 @@
 defmodule Rolodex.Mocks.TestController do
+  use Phoenix.Controller, namespace: Rolodex.Mocks
+
   alias Rolodex.Mocks.{
     UserRequestBody,
     UserResponse,

--- a/test/support/mocks/phoenix_routers.ex
+++ b/test/support/mocks/phoenix_routers.ex
@@ -1,0 +1,20 @@
+defmodule Rolodex.Mocks.TestPhoenixRouter do
+  use Phoenix.Router
+
+  scope "/api", Rolodex.Mocks do
+    get("/demo", TestController, :index)
+    post("/demo/:id", TestController, :conflicted)
+    put("/demo/:id", TestController, :with_bare_maps)
+    delete("/demo/:id", TestController, :undocumented)
+
+    # Multi-headed action function
+    get("/multi", TestController, :multi)
+    get("/nested/:nested_id/multi", TestController, :multi)
+
+    # This action function uses schemas for query and path params plus partials
+    get("/partials", TestController, :params_via_schema)
+
+    # This route action does not exist
+    put("/demo/missing/:id", TestController, :missing_action)
+  end
+end

--- a/test/support/mocks/routers.ex
+++ b/test/support/mocks/routers.ex
@@ -1,20 +1,21 @@
 defmodule Rolodex.Mocks.TestRouter do
-  use Phoenix.Router
+  use Rolodex.Router
 
-  scope "/api", Rolodex.Mocks do
-    get("/demo", TestController, :index)
-    post("/demo/:id", TestController, :conflicted)
-    put("/demo/:id", TestController, :with_bare_maps)
-    delete("/demo/:id", TestController, :undocumented)
+  router Rolodex.Mocks.TestPhoenixRouter do
+    route(:get, "/api/demo")
+    routes([:post, :put, :delete], "/api/demo/:id")
+    get("/api/multi")
+    get("/api/nested/:nested_id/multi")
+    get("/api/partials")
 
-    # Multi-headed action function
-    get("/multi", TestController, :multi)
-    get("/nested/:nested_id/multi", TestController, :multi)
-
-    # This action function uses schemas for query and path params plus partials
-    get("/partials", TestController, :params_via_schema)
-
-    # This route action does not exist
-    put("/demo/missing/:id", TestController, :missing_action)
+    # This route is defined in the Phoenix router but it has no associated
+    # controller action
+    put("/api/demo/missing/:id")
   end
+end
+
+defmodule Rolodex.Mocks.MiniTestRouter do
+  use Rolodex.Router
+
+  router(Rolodex.Mocks.TestPhoenixRouter, do: get("/api/demo"))
 end


### PR DESCRIPTION
### Changes

- Adds `Rolodex.Router`, a new DSL for defining which routes Rolodex should compile for documentation. This is a breaking change and replaces the filter concept from <= v0.8.1. With this change, Rolodex should work for Phoenix v1.4.7 and greater.