### PR TITLE
Strip empty content body examples

### DIFF
--- a/lib/rolodex/processors/open_api.ex
+++ b/lib/rolodex/processors/open_api.ex
@@ -186,11 +186,16 @@ defmodule Rolodex.Processors.OpenAPI do
     |> process_content_body_headers(rest)
   end
 
-  defp process_content_body_ref_data(%{schema: schema, examples: examples}) do
+  defp process_content_body_ref_data(%{schema: schema, examples: examples})
+       when map_size(examples) > 0 do
     %{
       schema: process_schema_field(schema),
       examples: process_content_body_examples(examples)
     }
+  end
+
+  defp process_content_body_ref_data(%{schema: schema}) do
+    %{schema: process_schema_field(schema)}
   end
 
   defp process_content_body_examples(examples),

--- a/test/rolodex_test.exs
+++ b/test/rolodex_test.exs
@@ -106,7 +106,6 @@ defmodule RolodexTest do
                      "ErrorResponse" => %{
                        "content" => %{
                          "application/json" => %{
-                           "examples" => %{},
                            "schema" => %{
                              "properties" => %{
                                "message" => %{"type" => "string"},
@@ -136,13 +135,11 @@ defmodule RolodexTest do
                        },
                        "content" => %{
                          "application/json" => %{
-                           "examples" => %{},
                            "schema" => %{
                              "$ref" => "#/components/schemas/User"
                            }
                          },
                          "application/lolsob" => %{
-                           "examples" => %{},
                            "schema" => %{
                              "type" => "array",
                              "items" => %{
@@ -639,7 +636,6 @@ defmodule RolodexTest do
                      "ErrorResponse" => %{
                        "content" => %{
                          "application/json" => %{
-                           "examples" => %{},
                            "schema" => %{
                              "properties" => %{
                                "message" => %{"type" => "string"},


### PR DESCRIPTION
Some OpenAPI 3 documentation renderers error out when processing empty
examples in Request and Response content bodies. So when generating
OpenAPI 3 docs, we will strip out examples when they're empty.